### PR TITLE
Fix: squid:S1596, Collections.emptyList(), emptyMap() and emptySet() …

### DIFF
--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/CommandParser.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/CommandParser.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 public class CommandParser { // designed as a class in case we add config
     public Command[] toArgs(final String line) {
-        if (line == null || line.length() == 0) {
+        if (line == null || line.isEmpty()) {
             throw new IllegalArgumentException("Empty command.");
         }
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -179,7 +179,7 @@ public class Main implements Completer {
     public Object exec(String... args) throws Exception {
         final List<String> list = processSystemProperties(args);
 
-        final String command = (list.size() == 0) ? "help" : list.remove(0);
+        final String command = (list.isEmpty()) ? "help" : list.remove(0);
         args = list.toArray(new String[list.size()]);
 
         final Cmd cmd = commands.get(command);
@@ -220,7 +220,7 @@ public class Main implements Completer {
     public Collection<String> complete(final String buffer, final int cursorPosition) {
         final List<String> cmds = new ArrayList<String>();
 
-        if (buffer == null || buffer.length() == 0) {
+        if (buffer == null || buffer.isEmpty()) {
             final Set<String> cmd = commands.keySet();
             for (final String s : cmd) {
                 cmds.add(s + " ");

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
@@ -514,11 +514,11 @@ public class CmdMethod implements Cmd {
 
         final List<Object> converted = convert(args, needed, parameters);
 
-        if (args.list.size() > 0) {
+        if (!args.list.isEmpty()) {
             throw new IllegalArgumentException("Excess arguments: " + Join.join(", ", args.list));
         }
 
-        if (args.options.size() > 0) {
+        if (!args.options.isEmpty()) {
             throw new IllegalArgumentException("Unknown arguments: " + Join.join(", ", STRING_NAME_CALLBACK, args.options.keySet()));
         }
 
@@ -554,7 +554,7 @@ public class CmdMethod implements Cmd {
                 case SERVICE:
                     converted.add(environment.findService(parameter.getType()));
                     break;
-                case PLAIN: if (args.list.size() > 0) {
+                case PLAIN: if (!args.list.isEmpty()) {
                         needed.count--;
                         fillPlainParameter(args, needed, converted, parameter);
                     }
@@ -597,7 +597,7 @@ public class CmdMethod implements Cmd {
     private static Object convert(final Param parameter, final List<String> values, final String name) {
         final Class<?> type = parameter.getListableType();
 
-        if (parameter.isAnnotationPresent(Required.class) && values.size() == 0) {
+        if (parameter.isAnnotationPresent(Required.class) && values.isEmpty()) {
             if (parameter instanceof OptionParam) {
                 final OptionParam optionParam = (OptionParam) parameter;
                 throw new IllegalArgumentException(String.format("--%s must be specified at least once",
@@ -884,7 +884,7 @@ public class CmdMethod implements Cmd {
         }
 
         private void checkInvalid(final List<String> invalid) {
-            if (invalid.size() > 0) {
+            if (!invalid.isEmpty()) {
                 throw new IllegalArgumentException("Unknown options: " + Join.join(", ", STRING_NAME_CALLBACK, invalid));
             }
         }
@@ -905,13 +905,13 @@ public class CmdMethod implements Cmd {
                 }
             }
 
-            if (required.size() > 0) {
+            if (!required.isEmpty()) {
                 throw new IllegalArgumentException("Required: " + Join.join(", ", STRING_NAME_CALLBACK, required));
             }
         }
 
         private void checkRepeated(final Set<String> repeated) {
-            if (repeated.size() > 0) {
+            if (!repeated.isEmpty()) {
                 throw new IllegalArgumentException("Cannot be specified more than once: " + Join.join(", ", repeated));
             }
         }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/OverloadedCmdMethod.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/OverloadedCmdMethod.java
@@ -96,7 +96,7 @@ public class OverloadedCmdMethod implements Cmd {
 
     @Override
     public void help(final PrintStream out) {
-        if (methods.size() == 0) {
+        if (methods.isEmpty()) {
             throw new IllegalStateException("No method in group: " + name);
         }
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
@@ -140,7 +140,7 @@ public class Commands {
     }
 
     public static String value(final String value, final String defaultValue) {
-        return value == null || value.length() == 0 ? defaultValue : value;
+        return value == null || value.isEmpty() ? defaultValue : value;
     }
 
     /**

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Help.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Help.java
@@ -48,7 +48,7 @@ public class Help {
     public static void optionHelp(final Class<?> clazz, final String commandName,
                                   final Collection<OptionParam> optionParams, final PrintStream out)
     {
-        if (optionParams.size() == 0) {
+        if (optionParams.isEmpty()) {
             return;
         }
 
@@ -83,7 +83,7 @@ public class Help {
             }
 
             lines.addAll(item.note);
-            if (lines.size() == 0) {
+            if (lines.isEmpty()) {
                 lines.add("");
             }
 
@@ -145,7 +145,7 @@ public class Help {
                 alias.add(aliasName);
             }
 
-            final boolean hasAlias = alias.size() > 0;
+            final boolean hasAlias = !alias.isEmpty();
             final Class<?> type = p.getType();
 
             String defaultValue = p.getDefaultValue();
@@ -173,7 +173,7 @@ public class Help {
                 if (p.isListable()) {
                     final List<String> defaultValues = p.getDefaultValues();
 
-                    if (defaultValues.size() > 0) {
+                    if (!defaultValues.isEmpty()) {
                         this.note.add(String.format("default: %s", Join.join(", ", defaultValues)));
                     }
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/OptionParam.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/OptionParam.java
@@ -51,7 +51,7 @@ public class OptionParam extends Param {
             return Collections.EMPTY_LIST;
         }
         final List<String> split = new ArrayList<String>(Arrays.asList(value.split(LIST_TYPE + "|" + LIST_SEPARATOR)));
-        if (split.size() > 0) {
+        if (!split.isEmpty()) {
             split.remove(0);
         }
         return split;

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/utils/CommandLine.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/utils/CommandLine.java
@@ -29,7 +29,7 @@ public class CommandLine {
     }
     
     public static String[] translateCommandline(String toProcess) {
-        if (toProcess == null || toProcess.length() == 0) {
+        if (toProcess == null || toProcess.isEmpty()) {
             // no command? no string
             return new String[0];
         }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BVal05.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BVal05.java
@@ -55,7 +55,7 @@ public class BVal05 implements BeanValidation.BeanValidationImpl {
         try {
             final Set<ConstraintViolation<?>> violations = Set.class.cast(
                 validateMethodParameters.invoke(getValidatorObject(), instanceOrClass.getClass(), method, parameters, NO_GROUP));
-            if (violations.size() > 0) {
+            if (!violations.isEmpty()) {
                 throw new ConstraintViolationException(violations);
             }
         } catch (final IllegalAccessException e) {
@@ -70,7 +70,7 @@ public class BVal05 implements BeanValidation.BeanValidationImpl {
         try {
             final Set<ConstraintViolation<?>> violations = Set.class.cast(
                 validateConstructorParamters.invoke(getValidatorObject(), constructor.getDeclaringClass(), constructor, parameters, NO_GROUP));
-            if (violations.size() > 0) {
+            if (!violations.isEmpty()) {
                 throw new ConstraintViolationException(violations);
             }
         } catch (final IllegalAccessException e) {

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation11.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation11.java
@@ -39,7 +39,7 @@ public class BeanValidation11 implements BeanValidation.BeanValidationImpl {
         }
         final ExecutableValidator executableValidator = validatorFactory.getValidator().forExecutables();
         final Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(instanceOrClass, method, parameters);
-        if (violations.size() > 0) {
+        if (!violations.isEmpty()) {
             throw new ConstraintViolationException(violations);
         }
     }
@@ -48,7 +48,7 @@ public class BeanValidation11 implements BeanValidation.BeanValidationImpl {
     public void validateParameters(final Constructor constructor, final Object[] parameters) {
         final ExecutableValidator executableValidator = validatorFactory.getValidator().forExecutables();
         final Set<ConstraintViolation<?>> violations = executableValidator.validateConstructorParameters(constructor, parameters);
-        if (violations.size() > 0) {
+        if (!violations.isEmpty()) {
             throw new ConstraintViolationException(violations);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1596 - “Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1596

 Please let me know if you have any questions.
Ayman Elkfrawy.