### PR TITLE
Fix: squid:S2293, The operator ("<>") should be used.

### DIFF
--- a/crest-maven-plugin/src/main/java/org/tomitribe/crest/maven/CrestCommandLoaderDescriptorGeneratorMojo.java
+++ b/crest-maven-plugin/src/main/java/org/tomitribe/crest/maven/CrestCommandLoaderDescriptorGeneratorMojo.java
@@ -59,7 +59,7 @@ public class CrestCommandLoaderDescriptorGeneratorMojo extends AbstractMojo {
         }
 
         // find commands
-        final Collection<String> commands = new TreeSet<String>(); // sorted if a human wants to check it
+        final Collection<String> commands = new TreeSet<>(); // sorted if a human wants to check it
         try {
             scan(commands, classes);
         } catch (final IOException e) {

--- a/crest-maven-plugin/src/test/java/org/tomitribe/crest/maven/CrestCommandLoaderDescriptorGeneratorMojoTest.java
+++ b/crest-maven-plugin/src/test/java/org/tomitribe/crest/maven/CrestCommandLoaderDescriptorGeneratorMojoTest.java
@@ -43,7 +43,7 @@ public class CrestCommandLoaderDescriptorGeneratorMojoTest {
         mojo.execute();
 
         final BufferedReader reader = new BufferedReader(new FileReader(mojo.output));
-        final Collection<String> found = new HashSet<String>();
+        final Collection<String> found = new HashSet<>();
         String line;
         while ((line = reader.readLine()) != null) {
             found.add(line);

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/CrestCli.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/CrestCli.java
@@ -91,15 +91,15 @@ public class CrestCli {
     private CliEnvironment mainEnvironment;
 
     public void run(final String... args) throws Exception {
-        final AtomicReference<InputReader> inputReaderRef = new AtomicReference<InputReader>();
-        final AtomicReference<History> historyRef = new AtomicReference<History>();
+        final AtomicReference<InputReader> inputReaderRef = new AtomicReference<>();
+        final AtomicReference<History> historyRef = new AtomicReference<>();
         mainEnvironment = createMainEnvironment(inputReaderRef, historyRef);
         Environment.ENVIRONMENT_THREAD_LOCAL.set(mainEnvironment);
 
         final DefaultsContext ctx = new SystemPropertiesDefaultsContext();
         final Main main = newMain(ctx);
 
-        final Map<String, String> aliasesMapping = new HashMap<String, String>();
+        final Map<String, String> aliasesMapping = new HashMap<>();
         final File aliases = aliasesFile();
         if (aliases != null && aliases.isFile()) {
             aliasesMapping.putAll(Map.class.cast(IO.readProperties(aliases)));
@@ -255,7 +255,7 @@ public class CrestCli {
                                     }
                                 }
 
-                                final Collection<Future<?>> tasks = new ArrayList<Future<?>>(commands.length);
+                                final Collection<Future<?>> tasks = new ArrayList<>(commands.length);
 
                                 for (int i = 0; i < commands.length; i++) {
                                     final int idx = i;

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/format/Table.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/format/Table.java
@@ -31,7 +31,7 @@ public class Table {
     private static final String LINE_CHAR = "-";
     private static final char EMPTY_CHAR = ' ';
 
-    private final List<Row> rows = new LinkedList<Row>();
+    private final List<Row> rows = new LinkedList<>();
     private final String cr;
     private final Row header;
 
@@ -45,7 +45,7 @@ public class Table {
             throw new IllegalArgumentException("columns should have all the same size");
         }
 
-        final Collection<String> str = new ArrayList<String>(columns.length);
+        final Collection<String> str = new ArrayList<>(columns.length);
         for (final Object o : columns) {
             str.add(String.valueOf(o));
         }
@@ -67,7 +67,7 @@ public class Table {
     }
 
     public void printHorizontal(final PrintStream printStream) {
-        final List<Integer> width = new ArrayList<Integer>(rows.size());
+        final List<Integer> width = new ArrayList<>(rows.size());
         for (int i = 0; i < header.columns.length; i++) {
             if (width.size() <= i) {
                 width.add(header.columns[i].length());

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/interceptor/base/ParameterVisitor.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/interceptor/base/ParameterVisitor.java
@@ -88,11 +88,11 @@ public final class ParameterVisitor {
             return null;
         }
 
-        List<Object> constructorParam = bean == null ? new ArrayList<Object>() : null;
+        List<Object> constructorParam = bean == null ? new ArrayList<>() : null;
         try {
             final Constructor constructor = Class.class.cast(type).getConstructors()[0];
             final BeanInfo descriptor = Introspector.getBeanInfo(Class.class.cast(type));
-            final Map<String, PropertyDescriptor> descriptorMap = new HashMap<String, PropertyDescriptor>();
+            final Map<String, PropertyDescriptor> descriptorMap = new HashMap<>();
             for (final PropertyDescriptor d : descriptor.getPropertyDescriptors()) {
                 descriptorMap.put(d.getName(), d);
             }

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/CommandParser.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/CommandParser.java
@@ -25,8 +25,8 @@ public class CommandParser { // designed as a class in case we add config
             throw new IllegalArgumentException("Empty command.");
         }
 
-        final List<Command> commands = new ArrayList<Command>();
-        final List<String> result = new ArrayList<String>();
+        final List<Command> commands = new ArrayList<>();
+        final List<String> result = new ArrayList<>();
         final StringBuilder current = new StringBuilder();
 
         char waitChar = ' ';

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/command/Streams.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/command/Streams.java
@@ -55,7 +55,7 @@ public class Streams {
         if (pattern == null) {
             throw new NullPointerException("Pattern shouldnt be null");
         }
-        final Collection<Predicate<String>> predicates = new ArrayList<Predicate<String>>();
+        final Collection<Predicate<String>> predicates = new ArrayList<>();
         for (final String patt : pattern.split("\\|")) {
             predicates.add(isRegex ?
                 new Predicate<String>() {

--- a/tomitribe-crest-xbean/src/main/java/org/tomitribe/crest/xbean/XbeanScanningLoader.java
+++ b/tomitribe-crest-xbean/src/main/java/org/tomitribe/crest/xbean/XbeanScanningLoader.java
@@ -27,7 +27,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 public abstract class XbeanScanningLoader implements Commands.Loader {
-    final Set<Class<?>> classes = new HashSet<Class<?>>();
+    final Set<Class<?>> classes = new HashSet<>();
 
     public XbeanScanningLoader(final Archive archive) {
         final AnnotationFinder finder = new AnnotationFinder(archive);

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -47,8 +47,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class Main implements Completer {
 
-    protected final Map<String, Cmd> commands = new ConcurrentHashMap<String, Cmd>();
-    protected final Map<Class<?>, InternalInterceptor> interceptors = new HashMap<Class<?>, InternalInterceptor>();
+    protected final Map<String, Cmd> commands = new ConcurrentHashMap<>();
+    protected final Map<Class<?>, InternalInterceptor> interceptors = new HashMap<>();
 
     public Main() {
         this(new SystemPropertiesDefaultsContext(), Commands.load());
@@ -197,7 +197,7 @@ public class Main implements Completer {
     }
 
     public static List<String> processSystemProperties(final String[] args) {
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         // Read in and apply the properties specified on the command line
         for (final String arg : args) {
@@ -218,7 +218,7 @@ public class Main implements Completer {
 
     @Override
     public Collection<String> complete(final String buffer, final int cursorPosition) {
-        final List<String> cmds = new ArrayList<String>();
+        final List<String> cmds = new ArrayList<>();
 
         if (buffer == null || buffer.length() == 0) {
             final Set<String> cmd = commands.keySet();

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdGroup.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdGroup.java
@@ -35,7 +35,7 @@ import org.tomitribe.crest.interceptor.internal.InternalInterceptor;
 public class CmdGroup implements Cmd {
 
     final String name;
-    final Map<String, Cmd> commands = new TreeMap<String, Cmd>();
+    final Map<String, Cmd> commands = new TreeMap<>();
 
     public CmdGroup(final Class<?> owner, final Map<String, Cmd> commands) {
         this.name = Commands.name(owner);
@@ -88,7 +88,7 @@ public class CmdGroup implements Cmd {
         out.printf("   %-20s", "");
         out.println();
 
-        final SortedSet<String> strings = new TreeSet<String>(new Comparator<String>() {
+        final SortedSet<String> strings = new TreeSet<>(new Comparator<String>() {
             @Override
             public int compare(final String s1, final String s2) {
                 assert null != s1;
@@ -116,7 +116,7 @@ public class CmdGroup implements Cmd {
     @Override
     public Collection<String> complete(final String buffer, final int cursorPosition) {
 
-        final List<String> results = new ArrayList<String>();
+        final List<String> results = new ArrayList<>();
 
         try {
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
@@ -108,9 +108,9 @@ public class CmdMethod implements Cmd {
     private volatile List<ParameterMetadata> parameterMetadatas;
 
     public class Spec {
-        private final Map<String, OptionParam> options = new TreeMap<String, OptionParam>();
-        private final Map<String, OptionParam> aliases = new TreeMap<String, OptionParam>();
-        private final List<Param> arguments = new LinkedList<Param>();
+        private final Map<String, OptionParam> options = new TreeMap<>();
+        private final Map<String, OptionParam> aliases = new TreeMap<>();
+        private final List<Param> arguments = new LinkedList<>();
     }
 
     public CmdMethod(final Method method, final DefaultsContext defaultsFinder) {
@@ -135,7 +135,7 @@ public class CmdMethod implements Cmd {
 
     private List<Param> buildParams(final String globalDescription, final String[] inPrefixes, final Defaults defaults, final Iterable<Parameter> params) {
         final String[] prefixes = inPrefixes == null ? NO_PREFIX : inPrefixes;
-        final List<Param> parameters = new ArrayList<Param>();
+        final List<Param> parameters = new ArrayList<>();
         for (final Parameter parameter : params) {
 
             if (parameter.isAnnotationPresent(Option.class)) {
@@ -303,7 +303,7 @@ public class CmdMethod implements Cmd {
             }
         }
 
-        final List<Object> args = new ArrayList<Object>();
+        final List<Object> args = new ArrayList<>();
 
         for (final Param parameter : spec.arguments) {
             boolean skip = Environment.class.isAssignableFrom(parameter.getType());
@@ -369,7 +369,7 @@ public class CmdMethod implements Cmd {
     }
 
     private List<ParameterMetadata> buildApiParameterViews(final List<Param> parameters) {
-        final List<ParameterMetadata> parameterMetadatas = new ArrayList<ParameterMetadata>();
+        final List<ParameterMetadata> parameterMetadatas = new ArrayList<>();
         for (final Param param : parameters) {
             // precompute all values to get a fast runtime immutable structure
             final ParameterMetadata.ParamType type = OptionParam.class.isInstance(param) ?  OPTION :
@@ -534,7 +534,7 @@ public class CmdMethod implements Cmd {
          *
          * Thus, iteration order is very significant in this loop.
          */
-        final List<Object> converted = new ArrayList<Object>();
+        final List<Object> converted = new ArrayList<>();
         final Environment environment = Environment.ENVIRONMENT_THREAD_LOCAL.get();
         for (final Param parameter : parameters1) {
             final ParameterMetadata apiView = parameter.getApiView();
@@ -583,7 +583,7 @@ public class CmdMethod implements Cmd {
 
     private void fillPlainParameter(final Arguments args, final Needed needed, final List<Object> converted, final Param parameter) {
         if (parameter.isListable()) {
-            final List<String> glob = new ArrayList<String>(args.list.size());
+            final List<String> glob = new ArrayList<>(args.list.size());
             for (int i = args.list.size(); i > needed.count; i--) {
                 glob.add(args.list.remove(0));
             }
@@ -667,36 +667,36 @@ public class CmdMethod implements Cmd {
 
             // Sets
             if (NavigableSet.class.isAssignableFrom(aClass)) {
-                return new TreeSet<Object>();
+                return new TreeSet<>();
             }
             if (SortedSet.class.isAssignableFrom(aClass)) {
-                return new TreeSet<Object>();
+                return new TreeSet<>();
             }
             if (Set.class.isAssignableFrom(aClass)) {
-                return new LinkedHashSet<Object>();
+                return new LinkedHashSet<>();
             }
 
             // Queues
             if (Deque.class.isAssignableFrom(aClass)) {
-                return new LinkedList<Object>();
+                return new LinkedList<>();
             }
             if (Queue.class.isAssignableFrom(aClass)) {
-                return new LinkedList<Object>();
+                return new LinkedList<>();
             }
 
             // Lists
             if (List.class.isAssignableFrom(aClass)) {
-                return new ArrayList<Object>();
+                return new ArrayList<>();
             }
 
             // Collection
             if (Collection.class.isAssignableFrom(aClass)) {
-                return new LinkedList<Object>();
+                return new LinkedList<>();
             }
 
             // Iterable
             if (Iterable.class.isAssignableFrom(aClass)) {
-                return new LinkedList<Object>();
+                return new LinkedList<>();
             }
 
             throw new IllegalStateException("Unsupported Collection type: " + aClass.getName());
@@ -725,7 +725,7 @@ public class CmdMethod implements Cmd {
     }
 
     public Map<String, String> getDefaults() {
-        final Map<String, String> options = new HashMap<String, String>();
+        final Map<String, String> options = new HashMap<>();
 
         for (final OptionParam parameter : spec.options.values()) {
             options.put(parameter.getName(), parameter.getDefaultValue());
@@ -735,16 +735,16 @@ public class CmdMethod implements Cmd {
     }
 
     private class Arguments {
-        private final List<String> list = new ArrayList<String>();
-        private final Map<String, String> options = new HashMap<String, String>();
+        private final List<String> list = new ArrayList<>();
+        private final Map<String, String> options = new HashMap<>();
 
         private Arguments(final String[] rawArgs) {
 
             final Map<String, String> defaults = getDefaults();
-            final Map<String, String> supplied = new HashMap<String, String>();
+            final Map<String, String> supplied = new HashMap<>();
 
-            final List<String> invalid = new ArrayList<String>();
-            final Set<String> repeated = new HashSet<String>();
+            final List<String> invalid = new ArrayList<>();
+            final Set<String> repeated = new HashSet<>();
 
             // Read in and apply the options specified on the command line
             for (final String arg : rawArgs) {
@@ -804,7 +804,7 @@ public class CmdMethod implements Cmd {
                     return;
                 }
 
-                final Set<String> opts = new HashSet<String>();
+                final Set<String> opts = new HashSet<>();
                 for (final String opt : name.split("(?!^)")) {
                     opts.add(opt);
                 }
@@ -890,7 +890,7 @@ public class CmdMethod implements Cmd {
         }
 
         private void checkRequired(final Map<String, String> supplied) {
-            final List<String> required = new ArrayList<String>();
+            final List<String> required = new ArrayList<>();
             for (final Param parameter : spec.options.values()) {
                 if (!parameter.isAnnotationPresent(Required.class)) {
                     continue;
@@ -924,7 +924,7 @@ public class CmdMethod implements Cmd {
 
     @Override
     public Collection<String> complete(final String buffer, final int cursorPosition) {
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         final String commandLine = buffer.substring(0, cursorPosition);
         final String[] args = CommandLine.translateCommandline(commandLine);
 
@@ -941,7 +941,7 @@ public class CmdMethod implements Cmd {
     }
 
     private Collection<String> findMatcingParametersOptions(String prefix, boolean isIncludeAliasChar) {
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         for (Param param : parameters) {
             if (param instanceof OptionParam) {
                 final OptionParam optionParam = (OptionParam) param;
@@ -966,7 +966,7 @@ public class CmdMethod implements Cmd {
     }
 
     private Collection<String> findMatchingAliasOptions(String prefix, boolean isIncludeAliasChar) {
-        final List<String> result = new ArrayList<String>();
+        final List<String> result = new ArrayList<>();
         for (String alias : spec.aliases.keySet()) {
             if (alias.startsWith(prefix)) {
                 if (alias.startsWith("-")) {
@@ -983,7 +983,7 @@ public class CmdMethod implements Cmd {
     }
 
     private Collection<String> findMatchingOptions(String prefix, boolean isIncludeAliasChar) {
-        List<String> results = new ArrayList<String>();
+        List<String> results = new ArrayList<>();
         results.addAll(findMatcingParametersOptions(prefix, isIncludeAliasChar));
         results.addAll(findMatchingAliasOptions(prefix, isIncludeAliasChar));
         return results;

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/OverloadedCmdMethod.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/OverloadedCmdMethod.java
@@ -39,7 +39,7 @@ public class OverloadedCmdMethod implements Cmd {
     public OverloadedCmdMethod(final String name) {
         this.name = name;
 
-        this.methods = new TreeSet<CmdMethod>(new Comparator<CmdMethod>() {
+        this.methods = new TreeSet<>(new Comparator<CmdMethod>() {
             @Override
             public int compare(final CmdMethod a, final CmdMethod b) {
                 return a.getArgumentParameters().size() - b.getArgumentParameters().size();
@@ -111,7 +111,7 @@ public class OverloadedCmdMethod implements Cmd {
         }
         out.println();
 
-        final Map<String, OptionParam> options = new TreeMap<String, OptionParam>();
+        final Map<String, OptionParam> options = new TreeMap<>();
         for (final CmdMethod method : methods) {
             options.putAll(method.getOptionParameters());
         }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
@@ -52,7 +52,7 @@ public class Commands {
     }
 
     public static Iterable<Method> commands(final Class<?> clazz) {
-        return new FilteredIterable<Method>(Reflection.methods(clazz),
+        return new FilteredIterable<>(Reflection.methods(clazz),
                 new FilteredIterator.Filter<Method>() {
                     @Override
                     public boolean accept(final Method method) {
@@ -83,7 +83,7 @@ public class Commands {
             throw new IllegalArgumentException("Target cannot be null");
         }
 
-        final Map<String, Cmd> map = new HashMap<String, Cmd>();
+        final Map<String, Cmd> map = new HashMap<>();
 
         for (final Method method : commands(clazz)) {
 
@@ -113,7 +113,7 @@ public class Commands {
 
             final CmdGroup cmdGroup = new CmdGroup(clazz, map);
 
-            final HashMap<String, Cmd> group = new HashMap<String, Cmd>();
+            final HashMap<String, Cmd> group = new HashMap<>();
             group.put(cmdGroup.getName(), cmdGroup);
 
             return group;
@@ -165,7 +165,7 @@ public class Commands {
         final Iterator<Loader> all = ServiceLoader.load(Loader.class, loader).iterator();
 
         // Let them tell is the list of classes to use
-        final LinkedHashSet<Class<?>> classes = new LinkedHashSet<Class<?>>();
+        final LinkedHashSet<Class<?>> classes = new LinkedHashSet<>();
 
         while (all.hasNext()) {
             final Iterable<Class<?>> c = all.next();

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Help.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Help.java
@@ -54,7 +54,7 @@ public class Help {
 
         ResourceBundle general = null; // lazily loaded cause breaks the annotation driven API so not considered as default
 
-        final List<Item> items = new ArrayList<Item>(optionParams.size());
+        final List<Item> items = new ArrayList<>(optionParams.size());
 
         int width = 20;
         for (final OptionParam optionParam : optionParams) {
@@ -76,7 +76,7 @@ public class Help {
         out.println("Options: ");
 
         for (final Item item : items) {
-            final List<String> lines = new ArrayList<String>();
+            final List<String> lines = new ArrayList<>();
 
             if (item.description != null) {
                 lines.add(item.description);
@@ -130,14 +130,14 @@ public class Help {
     private static class Item {
 
         private final String flag;
-        private final List<String> note = new LinkedList<String>();
+        private final List<String> note = new LinkedList<>();
         private final String description;
 
         private Item(final OptionParam p, final String description) {
             this.description = description;
             final String prefix = p.getName().length() > 1 ? "--" : "-";
             
-            final List<String> alias = new ArrayList<String>();
+            final List<String> alias = new ArrayList<>();
 
             Option option = p.getAnnotation(Option.class);
             for (int i = 1; i < option.value().length; i++) {
@@ -217,7 +217,7 @@ public class Help {
         string.printf("   %-20s", "");
         string.println();
 
-        final SortedSet<String> strings = new TreeSet<String>(new Comparator<String>() {
+        final SortedSet<String> strings = new TreeSet<>(new Comparator<String>() {
             @Override
             public int compare(final String s1, final String s2) {
                 assert null != s1;

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/OptionParam.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/OptionParam.java
@@ -50,7 +50,7 @@ public class OptionParam extends Param {
         if (value == null) {
             return Collections.EMPTY_LIST;
         }
-        final List<String> split = new ArrayList<String>(Arrays.asList(value.split(LIST_TYPE + "|" + LIST_SEPARATOR)));
+        final List<String> split = new ArrayList<>(Arrays.asList(value.split(LIST_TYPE + "|" + LIST_SEPARATOR)));
         if (split.size() > 0) {
             split.remove(0);
         }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/utils/CommandLine.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/utils/CommandLine.java
@@ -40,7 +40,7 @@ public class CommandLine {
         final int inDoubleQuote = 2;
         int state = normal;
         StringTokenizer tok = new StringTokenizer(toProcess, "\"\' ", true);
-        Vector<String> v = new Vector<String>();
+        Vector<String> v = new Vector<>();
         StringBuffer current = new StringBuffer();
         boolean lastTokenHasBeenQuoted = false;
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation.java
@@ -76,7 +76,7 @@ public class BeanValidation {
         if (!ConstraintViolationException.class.isInstance(e)) {
             return singletonList(e.getMessage());
         }
-        final Collection<String> msg = new LinkedList<String>();
+        final Collection<String> msg = new LinkedList<>();
         final ConstraintViolationException cve = (ConstraintViolationException) e;
         for (final ConstraintViolation<?> violation : cve.getConstraintViolations()) {
             msg.add(violation.getMessage());

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/HelpTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/HelpTest.java
@@ -232,7 +232,7 @@ public class HelpTest extends Assert {
 
     @Test
     public void test() throws Exception {
-        final Map<Class, Map<String, Cmd>> parsed = new HashMap<Class, Map<String, Cmd>>();
+        final Map<Class, Map<String, Cmd>> parsed = new HashMap<>();
 
         final File base = getHelpBase();
 
@@ -373,7 +373,7 @@ public class HelpTest extends Assert {
 
         final AnnotationFinder finder = new AnnotationFinder(archive);
 
-        final Set<Class> classes = new TreeSet<Class>(new Comparator<Class>() {
+        final Set<Class> classes = new TreeSet<>(new Comparator<Class>() {
             @Override
             public int compare(final Class o1, final Class o2) {
                 return o1.getName().compareTo(o2.getName());

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/SubstitutionTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/SubstitutionTest.java
@@ -41,7 +41,7 @@ public class SubstitutionTest extends Assert {
 
     @Test
     public void test() throws Exception {
-        final Map<String, String> map = new HashMap<String, String>();
+        final Map<String, String> map = new HashMap<>();
         map.put("one", "uno");
         map.put("two", "dos");
         map.put("three", "tres");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator ("<>") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293

 Please let me know if you have any questions.
Ayman Elkfrawy.