### PR TITLE
Fix: squid:S2093, Try-with-resources should be used

### DIFF
--- a/crest-maven-plugin/src/main/java/org/tomitribe/crest/maven/CrestCommandLoaderDescriptorGeneratorMojo.java
+++ b/crest-maven-plugin/src/main/java/org/tomitribe/crest/maven/CrestCommandLoaderDescriptorGeneratorMojo.java
@@ -70,22 +70,12 @@ public class CrestCommandLoaderDescriptorGeneratorMojo extends AbstractMojo {
         if (!output.getParentFile().isDirectory() && !output.getParentFile().mkdirs()) {
             throw new MojoExecutionException("Can't create " + output.getAbsolutePath());
         }
-        FileWriter writer = null;
-        try {
-            writer = new FileWriter(output);
+        try (FileWriter writer = new FileWriter(output)){
             for (final String cmd : commands) {
                 writer.write(cmd + '\n');
             }
         } catch (final IOException e) {
             throw new MojoExecutionException(e.getMessage(), e);
-        } finally {
-            if (writer != null) {
-                try {
-                    writer.close();
-                } catch (final IOException e) {
-                    // no-op
-                }
-            }
         }
     }
 
@@ -108,9 +98,7 @@ public class CrestCommandLoaderDescriptorGeneratorMojo extends AbstractMojo {
     }
 
     private String commandName(final File classFile) throws IOException {
-        InputStream stream = null;
-        try {
-            stream = new FileInputStream(classFile);
+        try (InputStream stream = new FileInputStream(classFile)) {
             final ClassReader reader = new ClassReader(stream);
             reader.accept(new ClassVisitor(ASM5) {
                 private String className;
@@ -145,14 +133,6 @@ public class CrestCommandLoaderDescriptorGeneratorMojo extends AbstractMojo {
             }, SKIP_CODE + SKIP_DEBUG + SKIP_FRAMES);
         } catch (final CommandFoundException cfe) {
             return cfe.getMessage(); // class name
-        } finally {
-            try {
-                if (stream != null) {
-                    stream.close();
-                }
-            } catch (final IOException e) {
-                // no-op
-            }
         }
         return null;
     }

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/command/JSonP.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/command/JSonP.java
@@ -37,31 +37,18 @@ public final class JSonP {
 
     public static void format(final String content, final PrintStream out) {
         final JsonProvider provider = JsonProvider.provider();
-        JsonReader reader = null;
-        try {
-            reader = provider.createReaderFactory(Collections.<String, Object>emptyMap())
+        try (JsonReader reader = provider.createReaderFactory(Collections.<String, Object>emptyMap())
                 .createReader(new ByteArrayInputStream(content.getBytes("UTF-8")));
-            JsonWriter writer = null;
-            try {
-                writer = provider.createWriterFactory(singletonMap(JsonGenerator.PRETTY_PRINTING, "true"))
-                    .createWriter(new FilterOutputStream(out) {
-                        @Override
-                        public void close() throws IOException {
-                            super.flush(); // stdout shouldnt get closed
-                        }
-                    });
-                writer.write(reader.read());
-            } finally {
-                if (writer != null) {
-                    writer.close();
-                }
-            }
+             JsonWriter writer = provider.createWriterFactory(singletonMap(JsonGenerator.PRETTY_PRINTING, "true"))
+                     .createWriter(new FilterOutputStream(out) {
+                         @Override
+                         public void close() throws IOException {
+                             super.flush(); // stdout shouldnt get closed
+                         }
+                     });) {
+            writer.write(reader.read());
         } catch (final UnsupportedEncodingException e) {
             throw new IllegalStateException(e);
-        } finally {
-            if (reader != null) {
-                reader.close();
-            }
         }
     }
 }

--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/command/Streams.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/impl/command/Streams.java
@@ -74,9 +74,7 @@ public class Streams {
                 });
         }
 
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new InputStreamReader(in));
+         try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 for (final Predicate<String> p : predicates) {
@@ -88,14 +86,6 @@ public class Streams {
             }
         } catch (final IOException e) {
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                if (reader != null) {
-                    reader.close();
-                }
-            } catch (final IOException e) {
-                // no-op
-            }
         }
     }
 
@@ -106,40 +96,20 @@ public class Streams {
                           @Out final PrintStream out) {
         int count = 0;
         if (characters) {
-            Reader reader = null;
-            try {
-                reader = new InputStreamReader(in);
+            try (Reader reader = new InputStreamReader(in)) {
                 while (reader.read() >= 0) {
                     count++;
                 }
             } catch (final IOException e) {
                 throw new IllegalStateException(e);
-            } finally {
-                try {
-                    if (reader != null) {
-                        reader.close();
-                    }
-                } catch (final IOException e) {
-                    // no-op
-                }
             }
         } else if (line) {
-            BufferedReader reader = null;
-            try {
-                reader = new BufferedReader(new InputStreamReader(in));
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
                 while (reader.readLine() != null) {
                     count++;
                 }
             } catch (final IOException e) {
                 throw new IllegalStateException(e);
-            } finally {
-                try {
-                    if (reader != null) {
-                        reader.close();
-                    }
-                } catch (final IOException e) {
-                    // no-op
-                }
             }
         } else {
             throw new IllegalStateException("wc needs at least one active option");
@@ -167,23 +137,13 @@ public class Streams {
         final boolean global = command.endsWith("/g");
         final Pattern compiled = Pattern.compile(pattern);
 
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new InputStreamReader(in));
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in))) {
             String line;
             while ((line = reader.readLine()) != null) {
                 out.println(global ? compiled.matcher(line).replaceAll(substitution) : compiled.matcher(line).replaceFirst(substitution));
             }
         } catch (final IOException e) {
             throw new IllegalStateException(e);
-        } finally {
-            try {
-                if (reader != null) {
-                    reader.close();
-                }
-            } catch (final IOException e) {
-                // no-op
-            }
         }
     }
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
@@ -180,12 +180,8 @@ public class Commands {
                 final Enumeration<URL> urls = loader.getResources(prefix + "crest-commands.txt");
                 while (urls.hasMoreElements()) {
                     final URL url = urls.nextElement();
-                    InputStream stream = null;
-                    try {
-                        stream = url.openStream();
-                        BufferedReader reader = null;
-                        try {
-                            reader = new BufferedReader(new InputStreamReader(stream));
+                    try (InputStream stream = url.openStream();
+                         BufferedReader reader = new BufferedReader(new InputStreamReader(stream))) {
                             String line;
                             while ((line = reader.readLine()) != null) {
                                 try {
@@ -194,21 +190,8 @@ public class Commands {
                                     // no-op: we can log it but don't fail cause one command didn't load
                                 }
                             }
-                        } finally {
-                            if (reader != null) {
-                                reader.close();
-                            }
-                        }
                     } catch (final IOException ioe) {
                         // no-op
-                    } finally {
-                        if (stream != null) {
-                            try {
-                                stream.close();
-                            }catch (final IOException ioe) {
-                                // no-op
-                            }
-                        }
                     }
                 }
             } catch (final IOException e) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule:
 squid:S2093 - Try-with-resources should be used, which guarantees that the resource in question will be closed. Since the new syntax is closer to bullet-proof, it should be preferred over the older try/catch/finally version.

Please let me know if you have any questions.
Ayman Elkfrawy