### PR TITLE
Fix: squid:S1905, Redundant casts should not be used

### DIFF
--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -238,7 +238,7 @@ public class Main implements Completer {
             final String prefix = buffer.substring(0, cursorPosition);
             Iterator<String> iterator = commands.keySet().iterator();
             while (iterator.hasNext()) {
-                final String command = (String) iterator.next();
+                final String command = iterator.next();
                 if (command.startsWith(prefix)) {
                     cmds.add(command + " ");
                 }
@@ -254,7 +254,7 @@ public class Main implements Completer {
         final Iterator<String> iterator = this.commands.keySet().iterator();
 
         while (iterator.hasNext()) {
-            String cmd = (String) iterator.next();
+            String cmd = iterator.next();
             if (cmd.equals(commandName)) {
                 return this.commands.get(cmd);
             }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdGroup.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdGroup.java
@@ -148,7 +148,7 @@ public class CmdGroup implements Cmd {
                 // look at all the possible commands and return those that match
                 final Iterator<String> iterator = commands.keySet().iterator();
                 while (iterator.hasNext()) {
-                    final String commandName = (String) iterator.next();
+                    final String commandName = iterator.next();
                     if (commandName.startsWith(prefix)) {
                         results.add(commandName + " ");
                     }

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/ArgListsTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/ArgListsTest.java
@@ -120,9 +120,9 @@ public class ArgListsTest extends TestCase {
             assertNotNull(list);
 
             final Iterator<Integer> it = list.iterator();
-            assertEquals((Integer) (int) 2, it.next());
-            assertEquals((Integer) (int) 3, it.next());
-            assertEquals((Integer) (int) 5, it.next());
+            assertEquals((Integer) 2, it.next());
+            assertEquals((Integer) 3, it.next());
+            assertEquals((Integer) 5, it.next());
             assertFalse(it.hasNext());
         }
 

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/DefaultOptionListsAndOptionsTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/DefaultOptionListsAndOptionsTest.java
@@ -134,9 +134,9 @@ public class DefaultOptionListsAndOptionsTest extends TestCase {
             assertNotNull(list);
 
             final Iterator<Integer> it = list.iterator();
-            assertEquals((Integer) (int) 2, it.next());
-            assertEquals((Integer) (int) 3, it.next());
-            assertEquals((Integer) (int) 5, it.next());
+            assertEquals((Integer) 2, it.next());
+            assertEquals((Integer) 3, it.next());
+            assertEquals((Integer) 5, it.next());
             assertFalse(it.hasNext());
 
             assertEquals(Color.orange, colorParam);

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/DefaultOptionListsTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/DefaultOptionListsTest.java
@@ -122,9 +122,9 @@ public class DefaultOptionListsTest extends TestCase {
             assertNotNull(list);
 
             final Iterator<Integer> it = list.iterator();
-            assertEquals((Integer) (int) 2, it.next());
-            assertEquals((Integer) (int) 3, it.next());
-            assertEquals((Integer) (int) 5, it.next());
+            assertEquals((Integer) 2, it.next());
+            assertEquals((Integer) 3, it.next());
+            assertEquals((Integer) 5, it.next());
             assertFalse(it.hasNext());
         }
 

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/OptionListsTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/OptionListsTest.java
@@ -121,9 +121,9 @@ public class OptionListsTest extends TestCase {
             assertNotNull(list);
 
             final Iterator<Integer> it = list.iterator();
-            assertEquals((Integer) (int) 2, it.next());
-            assertEquals((Integer) (int) 3, it.next());
-            assertEquals((Integer) (int) 5, it.next());
+            assertEquals((Integer) 2, it.next());
+            assertEquals((Integer) 3, it.next());
+            assertEquals((Integer) 5, it.next());
             assertFalse(it.hasNext());
         }
 


### PR DESCRIPTION
"This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1905 - Redundant casts should not be used
 You can find more information about the issue here: 
https://sonar.spring.io/rules/show/squid:S1905

Please let me know if you have any questions.
Ayman Elkfrawy"