### PR TITLE
Fix: squid:S3027, use single quotes for char search instead of string

### DIFF
--- a/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/CrestCli.java
+++ b/tomitribe-crest-cli/src/main/java/org/tomitribe/crest/cli/api/CrestCli.java
@@ -119,7 +119,7 @@ public class CrestCli {
                 @Override
                 public int complete(final String buffer, final int cursor, final List<CharSequence> candidates) {
                     candidates.addAll(main.complete(buffer, cursor));
-                    return buffer.lastIndexOf(" ", cursor) + 1; // TODO: enhance it
+                    return buffer.lastIndexOf(' ', cursor) + 1; // TODO: enhance it
                 }
             });
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -203,8 +203,8 @@ public class Main implements Completer {
         for (final String arg : args) {
             if (arg.startsWith("-D")) {
 
-                final String name = arg.substring(arg.indexOf("-D") + 2, arg.indexOf("="));
-                final String value = arg.substring(arg.indexOf("=") + 1);
+                final String name = arg.substring(arg.indexOf("-D") + 2, arg.indexOf('='));
+                final String value = arg.substring(arg.indexOf('=') + 1);
 
                 final Properties properties = Environment.ENVIRONMENT_THREAD_LOCAL.get().getProperties();
                 properties.setProperty(name, value);

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
@@ -779,13 +779,13 @@ public class CmdMethod implements Cmd {
             String value;
             String prefix = defaultPrefix;
 
-            if (arg.indexOf("=") > 0) {
-                name = arg.substring(arg.indexOf(prefix) + prefix.length(), arg.indexOf("="));
+            if (arg.indexOf('=') > 0) {
+                name = arg.substring(arg.indexOf(prefix) + prefix.length(), arg.indexOf('='));
                 if (!defaults.containsKey(name) && !spec.aliases.containsKey(name)) {
-                    name = arg.substring(0, arg.indexOf("="));
+                    name = arg.substring(0, arg.indexOf('='));
                     prefix = "";
                 }
-                value = arg.substring(arg.indexOf("=") + 1);
+                value = arg.substring(arg.indexOf('=') + 1);
             } else {
                 if (arg.startsWith("--no-")) {
                     name = arg.substring(5);
@@ -799,7 +799,7 @@ public class CmdMethod implements Cmd {
             if ("-".equals(prefix)) {
 
                 // reject -del=true
-                if (arg.indexOf("=") > -1 && name.length() > 1) {
+                if (arg.indexOf('=') > -1 && name.length() > 1) {
                     invalid.add(prefix + name);
                     return;
                 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S3027 - String function use should be optimized for single characters as an indexOf or lastIndexOf call with a single letter String can be made more performant by switching to a call with a char argument.

Please let me know if you have any questions.
Ayman Elkfrawy