### PR TITLE
adding tomitribe-crest-generator module

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -763,6 +763,150 @@ Here is how to define it in your pom:
 </plugin>
 ----
 
+== DeltaSpike Annotation Processor
+
+
+Adding this dependency to your project:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.tomitribe</groupId>
+  <artifactId>tomitribe-crest-generator</artifactId>
+  <version>${crest.version}</version>
+  <scope>provided</scope>
+</dependency>
+----
+
+Crest Generator can integrates with DeltaSpike to generate binding pojo. It will split `@ConfigProperty` on first dot
+and create one binding per prefix.
+
+Here is an example:
+
+[source,java]
+----
+public class DeltaspikeBean {
+    @Inject
+    @ConfigProperty(name = "app.service.base", defaultValue = "http://localhost:8080")
+    private String base;
+
+    @Inject
+    @ConfigProperty(name = "app.service.retries")
+    private Integer retries;
+}
+----
+
+It will generate the following binding:
+
+[source,java]
+----
+package org.tomitribe.crest.generator.generated;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.apache.deltaspike.core.api.config.ConfigResolver;
+import org.apache.deltaspike.core.spi.config.ConfigSource;
+import org.tomitribe.crest.api.Default;
+import org.tomitribe.crest.api.Option;
+
+import static java.util.Collections.singletonList;
+
+public class App {
+    private String serviceBase;
+    private Integer serviceRetries;
+
+    public App(
+        @Option("service-base") @Default("http://localhost:8080") String serviceBase,
+        @Option("service-retries") Integer serviceRetries) {
+        final Map<String, String> ____properties = new HashMap<>();
+        this.serviceBase = serviceBase;
+        ____properties.put("app.service.base", String.valueOf(serviceBase));
+        this.serviceRetries = serviceRetries;
+        ____properties.put("app.service.retries", String.valueOf(serviceRetries));
+        ConfigResolver.addConfigSources(Collections.<ConfigSource>singletonList(new ConfigSource() {
+            @Override
+            public int getOrdinal() {
+                return 0;
+            }
+
+            @Override
+            public Map<String, String> getProperties() {
+                return ____properties;
+            }
+
+            @Override
+            public String getPropertyValue(final String key) {
+                return ____properties.get(key);
+            }
+
+            @Override
+            public String getConfigName() {
+                return "crest-app";
+            }
+
+            @Override
+            public boolean isScannable() {
+                return true;
+            }
+        }));    }
+
+    public String getServiceBase() {
+        return serviceBase;
+    }
+
+    public void setServiceBase(final String serviceBase) {
+        this.serviceBase = serviceBase;
+    }
+
+    public Integer getServiceRetries() {
+        return serviceRetries;
+    }
+
+    public void setServiceRetries(final Integer serviceRetries) {
+        this.serviceRetries = serviceRetries;
+    }
+
+}
+----
+
+Then you just need to reuse it ad a crest command parameter:
+
+[source,java]
+----
+@Command
+public void myCommand(@Option("app-") final App app) {
+  // ...
+}
+----
+
+The nice thing is it will integrate with crest of course but also with DeltaSpike. It means the previous code
+will also make DeltaSpike injection respecting `App` configuration (`--app-service-base=... --app-service-retries=3` for instance).
+
+If you create a fatjar using TomEE embedded it means you can handle all your DeltaSpike configuration this way
+and you just need to write a TomEE Embedded runner to get DeltaSpike configuration wired from the command line:
+
+[source,java]
+----
+import org.apache.tomee.embedded.Main;
+
+public final class Runner {
+    @Command("run")
+    public static void run(@Option("app-") App app) {
+        Main.main(new String[] { "--as-war", "--single-classloader" } /*fatjar "as war" deployment*/);
+        // automatically @Inject @ConfigProperty will be populated :)
+    }
+}
+----
+
+Potential enhancement(s):
+
+- option to generate TomEE Embedded main?
+- Tamaya integration on the same model?
+- Owner integration
+- ...
+
 == Cli module
 
 Cli module aims to provide a basic integration with JLine.

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
     <module>toolz</module>
     <module>crest-maven-plugin</module>
     <module>tomitribe-crest-cli</module>
+    <module>tomitribe-crest-generator</module>
   </modules>
 
   <properties>

--- a/tomitribe-crest-generator/pom.xml
+++ b/tomitribe-crest-generator/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- $Rev: 1387962 $ $Date: 2012-09-20 05:53:17 -0500 (Thu, 20 Sep 2012) $ -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.tomitribe</groupId>
+    <artifactId>tomitribe-crest-parent</artifactId>
+    <version>0.10-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>tomitribe-crest-generator</artifactId>
+  <packaging>jar</packaging>
+  <name>Tomitribe :: Crest :: Generator</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.tomee</groupId>
+      <artifactId>javaee-api</artifactId>
+      <version>7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.deltaspike.core</groupId>
+      <artifactId>deltaspike-core-api</artifactId>
+      <version>1.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.tomitribe</groupId>
+      <artifactId>tomitribe-crest-api</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <compilerArgument>-proc:none</compilerArgument>
+            </configuration>
+          </execution>
+          <execution>
+            <id>default-testCompile</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <annotationProcessors>
+                <annotationProcessor>org.tomitribe.crest.generator.CrestBindingGeneratorProcessor</annotationProcessor>
+              </annotationProcessors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tomitribe-crest-generator/src/main/java/org/tomitribe/crest/generator/CrestBindingGeneratorProcessor.java
+++ b/tomitribe-crest-generator/src/main/java/org/tomitribe/crest/generator/CrestBindingGeneratorProcessor.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.generator;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.singleton;
+import static javax.lang.model.element.ElementKind.ANNOTATION_TYPE;
+import static javax.tools.Diagnostic.Kind.ERROR;
+import static javax.tools.Diagnostic.Kind.NOTE;
+
+@SupportedAnnotationTypes({
+        "org.apache.deltaspike.core.api.config.ConfigProperty"
+})
+public class CrestBindingGeneratorProcessor extends AbstractProcessor {
+    private String basePck;
+
+    @Override
+    public void init(final ProcessingEnvironment processingEnv) {
+        super.init(processingEnv);
+        final Map<String, String> options = processingEnv.getOptions();
+        basePck = options.get("crest.basePackage");
+        if (basePck == null) {
+            basePck = "org.tomitribe.crest.generator.generated";
+        }
+    }
+
+    private final Map<String, Binding> mappings = new HashMap<>();
+
+    @Override
+    public boolean process(final Set<? extends TypeElement> annotations, final RoundEnvironment roundEnvironment) {
+        if (!roundEnvironment.processingOver()) {
+            if (!mappings.isEmpty()) { // avoid to redo it again and again
+                return false;
+            }
+
+            processingEnv.getMessager().printMessage(NOTE, "Processing configuration annotations");
+            mappings.clear();
+
+            for (final TypeElement annotation : annotations) {
+                if (annotation.getKind() != ANNOTATION_TYPE) {
+                    continue;
+                }
+
+                try {
+                    final Set<? extends Element> annotatedElements = roundEnvironment.getElementsAnnotatedWith(annotation);
+                    for (final Element e : annotatedElements) {
+                        for (final AnnotationMirror am : e.getAnnotationMirrors()) {
+                            if (!DeclaredType.class.isInstance(e.asType()) ||
+                                    !TypeElement.class.isInstance(DeclaredType.class.cast(e.asType()).asElement()) ||
+                                    !TypeElement.class.isInstance(am.getAnnotationType().asElement())) {
+                                continue;
+                            }
+
+                            final Name qualifiedName = TypeElement.class.cast(am.getAnnotationType().asElement()).getQualifiedName();
+                            if (qualifiedName.contentEquals("org.apache.deltaspike.core.api.config.ConfigProperty")) {
+                                processDeltaSpike(e, am);
+                            }
+                        }
+                    }
+                } catch (final Throwable t) {
+                    processingEnv.getMessager().printMessage(ERROR, t.getMessage());
+                }
+            }
+
+
+            try {
+                dump(processingEnv.getFiler());
+            } catch (final IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+        return false;
+    }
+
+    private void dump(final Filer filer) throws IOException {
+        for (final Map.Entry<String, Binding> binding : mappings.entrySet()) {
+            final Binding bindingValue = binding.getValue();
+            final JavaFileObject sourceFile = filer.createSourceFile(basePck + '.' + bindingValue.className);
+
+            try (final Writer writer = sourceFile.openWriter()) {
+                writer.write("package " + basePck + ";\n\n");
+                writer.write("import java.util.Collections;\n");
+                writer.write("import java.util.Map;\n");
+                writer.write("import java.util.HashMap;\n\n");
+                writer.write("import org.apache.deltaspike.core.api.config.ConfigResolver;\n");
+                writer.write("import org.apache.deltaspike.core.spi.config.ConfigSource;\n");
+                if (bindingValue.hasDefault) {
+                    writer.write("import org.tomitribe.crest.api.Default;\n");
+                }
+                writer.write("import org.tomitribe.crest.api.Option;\n\n");
+                writer.write("import static java.util.Collections.singletonList;\n\n");
+                writer.write("public class " + bindingValue.className + " {\n");
+
+                for (final Map.Entry<String, Entry> e : bindingValue.entries.entrySet()) {
+                    writer.write("    private " + e.getValue().type + " " + e.getValue().varName + ";\n");
+                }
+                writer.write("\n");
+
+                writer.write("    public " + bindingValue.className + "(\n");
+
+                final Iterator<Map.Entry<String, Entry>> iterator = bindingValue.entries.entrySet().iterator();
+                final StringBuilder constructorBody = new StringBuilder();
+                while (iterator.hasNext()) {
+                    final Map.Entry<String, Entry> entry = iterator.next();
+                    final Entry value = entry.getValue();
+                    final String var = value.varName;
+                    writer.write("        @Option(\"" + entry.getKey().replace('.', '-') + "\")");
+                    if (value.defaultValue != null) {
+                        writer.write(" @Default(\"" + value.defaultValue + "\")");
+                    }
+                    writer.write(" " + value.type + " " + var);
+                    constructorBody.append("        this.").append(var).append(" = ").append(var).append(";\n");
+                    constructorBody.append("        ____properties.put(\"").append(binding.getKey()).append('.').append(value.key)
+                            .append("\", String.valueOf(").append(var).append("));\n");
+                    if (iterator.hasNext()) {
+                        writer.write(",\n");
+                    } else {
+                        writer.write(") {\n");
+                        writer.write("        final Map<String, String> ____properties = new HashMap<>();\n");
+                        writer.write(constructorBody.toString());
+                    }
+                }
+                writer.write("        ConfigResolver.addConfigSources(Collections.<ConfigSource>singletonList(new ConfigSource() {\n" +
+                        "            @Override\n" +
+                        "            public int getOrdinal() {\n" +
+                        "                return 0;\n" +
+                        "            }\n" +
+                        "\n" +
+                        "            @Override\n" +
+                        "            public Map<String, String> getProperties() {\n" +
+                        "                return ____properties;\n" +
+                        "            }\n" +
+                        "\n" +
+                        "            @Override\n" +
+                        "            public String getPropertyValue(final String key) {\n" +
+                        "                return ____properties.get(key);\n" +
+                        "            }\n" +
+                        "\n" +
+                        "            @Override\n" +
+                        "            public String getConfigName() {\n" +
+                        "                return \"crest-" + binding.getKey() + "\";\n" +
+                        "            }\n" +
+                        "\n" +
+                        "            @Override\n" +
+                        "            public boolean isScannable() {\n" +
+                        "                return true;\n" +
+                        "            }\n" +
+                        "        }));");
+                // TODO: add ConfigResolver.addConfigSource(new ...)...
+                writer.write("    }\n");
+
+                for (final Map.Entry<String, Entry> e : bindingValue.entries.entrySet()) {
+                    final String varName = e.getValue().varName;
+                    final String methodSuffix = Character.toUpperCase(varName.charAt(0)) + varName.substring(1);
+                    writer.write("\n    public " + e.getValue().type + " get" + methodSuffix + "() {\n");
+                    writer.write("        return " + varName + ";\n");
+                    writer.write("    }\n\n");
+                    writer.write("    public void set" + methodSuffix + "(final " + e.getValue().type + " " + varName + ") {\n");
+                    writer.write("        this." + varName + " = " + varName + ";\n");
+                    writer.write("    }\n");
+                }
+                writer.write("\n");
+
+                writer.write("}\n");
+            } catch (final IOException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+
+    private void processDeltaSpike(final Element e, final AnnotationMirror am) {
+        final Map<? extends ExecutableElement, ? extends AnnotationValue> values = am.getElementValues();
+        String name = null;
+        String defaultValue = null;
+        for (final Map.Entry<? extends ExecutableElement, ? extends AnnotationValue> entry : values.entrySet()) {
+            final Name simpleName = entry.getKey().getSimpleName();
+            if (simpleName.contentEquals("name")) {
+                name = entry.getValue().getValue().toString();
+            } else if (simpleName.contentEquals("defaultValue")) {
+                defaultValue = entry.getValue().getValue().toString();
+                if ("org.apache.deltaspike.NullValueMarker".equals(defaultValue)) {
+                    defaultValue = null;
+                }
+            }
+        }
+        onEntry(name, defaultValue, TypeElement.class.cast(DeclaredType.class.cast(e.asType()).asElement()).getQualifiedName().toString());
+    }
+
+    private static String toVar(final String key) {
+        final StringBuilder builder = new StringBuilder(key.length());
+        boolean toLower = true;
+        boolean toUpper = false;
+        for (int i = 0; i < key.length(); i++) {
+            final char c = key.charAt(i);
+            switch (c) {
+                case '.':
+                    toUpper = true;
+                    toLower = false;
+                    break;
+                default:
+                    if (toLower) {
+                        builder.append(Character.toLowerCase(c));
+                        toLower = toUpper = false;
+                    } else if (toUpper) {
+                        builder.append(Character.toUpperCase(c));
+                        toLower = toUpper = false;
+                    } else {
+                        builder.append(c);
+                    }
+            }
+        }
+        return builder.toString().replace(" ", "_");
+    }
+
+    private static String toClassName(final String key) {
+        return Character.toUpperCase(key.charAt(0)) + toVar(key.substring(1));
+    }
+
+    private void onEntry(final String name, final String defaultValue, final String type) {
+        final int sep = name.indexOf('.');
+        if (sep < 0) {
+            return;
+        }
+        final String subName = name.substring(sep + 1);
+        final String key = name.substring(0, sep);
+        Binding binding = mappings.get(key);
+        if (binding == null) {
+            binding = new Binding(toClassName(key));
+            mappings.put(key, binding);
+        }
+        if (!binding.hasDefault && defaultValue != null) {
+            binding.hasDefault = true;
+        }
+        binding.entries.put(subName, new Entry(defaultValue, type, subName));
+    }
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return singleton(SourceVersion.latestSupported().name());
+    }
+
+    private static final class Binding {
+        private boolean hasDefault = false;
+        private final String className;
+        private final Map<String, Entry> entries = new HashMap<>();
+
+        private Binding(final String className) {
+            this.className = className;
+        }
+    }
+
+    private static final class Entry {
+        private final String defaultValue;
+        private final String type;
+        private final String varName;
+        private final String key;
+
+        private Entry(final String defaultValue, final String type, final String key) {
+            this.defaultValue = defaultValue;
+            this.type = type.replace("java.lang.", "");
+            this.varName = toVar(key);
+            this.key = key;
+        }
+    }
+}

--- a/tomitribe-crest-generator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/tomitribe-crest-generator/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.tomitribe.crest.generator.CrestBindingGeneratorProcessor

--- a/tomitribe-crest-generator/src/test/java/org/tomitribe/crest/generator/CrestBindingGeneratorProcessorTest.java
+++ b/tomitribe-crest-generator/src/test/java/org/tomitribe/crest/generator/CrestBindingGeneratorProcessorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.generator;
+
+import org.apache.deltaspike.core.api.config.ConfigProperty;
+import org.apache.deltaspike.core.api.config.ConfigResolver;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.junit.Assert.assertEquals;
+
+public class CrestBindingGeneratorProcessorTest {
+    @Test
+    public void generate() throws Exception {
+        try (final URLClassLoader loader = new URLClassLoader(
+                new URL[] {new File("target/generated-test-sources/test-annotations").toURI().toURL()},
+                Thread.currentThread().getContextClassLoader())) {
+            final Object i = loader.loadClass("org.tomitribe.crest.generator.generated.App").getConstructor(String.class, Integer.class)
+                    .newInstance("base", 1234);
+            assertEquals("base", i.getClass().getMethod("getServiceBase").invoke(i));
+            assertEquals(1234, i.getClass().getMethod("getServiceRetries").invoke(i));
+            assertEquals("1234", ConfigResolver.getPropertyValue("app.service.retries"));
+            assertEquals("base", ConfigResolver.getPropertyValue("app.service.base"));
+        }
+    }
+
+    public static class DeltaspikeBean {
+        @Inject
+        @ConfigProperty(name = "app.service.base", defaultValue = "http://localhost:8080")
+        private String base;
+
+        @Inject
+        @ConfigProperty(name = "app.service.retries")
+        private Integer retries;
+    }
+}


### PR DESCRIPTION
Idea is to be able to generate DeltaSpike integration directly at build time and make deltaspike config entries set up from the command line.

It is very useful when wrapping tomee embedded for instance.