### PR TITLE
Support CDI-style custom interceptor annotations

### DIFF
--- a/tomitribe-crest-api/src/main/java/org/tomitribe/crest/api/interceptor/CrestInterceptor.java
+++ b/tomitribe-crest-api/src/main/java/org/tomitribe/crest/api/interceptor/CrestInterceptor.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -27,6 +28,12 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * The signature needs to be public Object &lt;name&gt;(CrestContext ctx);
  */
 @Retention(RUNTIME)
-@Target(METHOD)
+@Target({METHOD, ANNOTATION_TYPE})
 public @interface CrestInterceptor {
+    /**
+     * When used on an annotation, allows the interceptor class to be supplied.  This
+     * is an alternative to using @Command(interceptedBy) to supply the interceptor
+     * class.
+     */
+    Class<?> value() default Object.class;
 }

--- a/tomitribe-crest-api/src/main/java/org/tomitribe/crest/api/interceptor/CrestInterceptor.java
+++ b/tomitribe-crest-api/src/main/java/org/tomitribe/crest/api/interceptor/CrestInterceptor.java
@@ -29,8 +29,4 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target(METHOD)
 public @interface CrestInterceptor {
-    /**
-     * @return the type used in @Command(interceptedBy) to require the interceptor.
-     */
-    Class<?> value() default Object.class;
 }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -83,20 +83,12 @@ public class Main implements Completer {
         if (!m.isEmpty()) {
             this.commands.putAll(m);
         } else {
-            for (final Method method : clazz.getMethods()) {
-                if (Object.class == method.getDeclaringClass()) {
-                    continue;
-                }
 
-                final CrestInterceptor interceptor = method.getAnnotation(CrestInterceptor.class);
-                if (interceptor != null) {
-                    final InternalInterceptor value = new InternalInterceptor(new SimpleBean(null), method);
-
-                    final Class<?> key = clazz;
-                    if (interceptors.put(key, value) != null) {
-                        throw new IllegalArgumentException(key + " interceptor is conflicting");
-                    }
-                }
+            final InternalInterceptor internalInterceptor = InternalInterceptor.from(clazz);
+            // DMB The original contribution from 9cc3fc328f4406fe7821fbad6669fd170a9186a9
+            // on 2015-09-13 contained this check so leaving it in for now.
+            if (interceptors.put(clazz, internalInterceptor) != null) {
+                throw new IllegalArgumentException(clazz + " interceptor is conflicting");
             }
         }
     }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -26,7 +26,6 @@ import org.tomitribe.crest.cmds.Completer;
 import org.tomitribe.crest.cmds.HelpPrintedException;
 import org.tomitribe.crest.cmds.processors.Commands;
 import org.tomitribe.crest.cmds.processors.Help;
-import org.tomitribe.crest.cmds.targets.SimpleBean;
 import org.tomitribe.crest.contexts.DefaultsContext;
 import org.tomitribe.crest.contexts.SystemPropertiesDefaultsContext;
 import org.tomitribe.crest.environments.Environment;
@@ -35,10 +34,11 @@ import org.tomitribe.crest.interceptor.internal.InternalInterceptor;
 import org.tomitribe.crest.table.Border;
 import org.tomitribe.crest.table.Data;
 import org.tomitribe.crest.table.Table;
+import org.tomitribe.crest.table.TableInterceptor;
 import org.tomitribe.crest.term.Screen;
 
 import java.io.PrintStream;
-import java.lang.reflect.Method;
+import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -75,6 +75,7 @@ public class Main implements Completer {
             processClass(defaultsContext, clazz);
         }
 
+        processClass(defaultsContext, TableInterceptor.class);
         installHelp(defaultsContext);
     }
 
@@ -85,12 +86,27 @@ public class Main implements Completer {
         } else {
 
             final InternalInterceptor internalInterceptor = InternalInterceptor.from(clazz);
-            // DMB The original contribution from 9cc3fc328f4406fe7821fbad6669fd170a9186a9
-            // on 2015-09-13 contained this check so leaving it in for now.
             if (interceptors.put(clazz, internalInterceptor) != null) {
                 throw new IllegalArgumentException(clazz + " interceptor is conflicting");
             }
+
+            for (final Annotation annotation : clazz.getDeclaredAnnotations()) {
+                if (isCustomInterceptorAnnotation(annotation)){
+                    if (interceptors.put(annotation.annotationType(), internalInterceptor) != null) {
+                        throw new IllegalArgumentException(clazz + " interceptor is conflicting");
+                    }
+                }
+            }
         }
+    }
+
+    private static boolean isCustomInterceptorAnnotation(final Annotation annotation) {
+        for (final Annotation declaredAnnotation : annotation.annotationType().getDeclaredAnnotations()) {
+            if (declaredAnnotation instanceof CrestInterceptor) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public Main(final Iterable<Class<?>> classes) {

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/Main.java
@@ -90,8 +90,10 @@ public class Main implements Completer {
 
                 final CrestInterceptor interceptor = method.getAnnotation(CrestInterceptor.class);
                 if (interceptor != null) {
-                    final Class<?> key = interceptor.value() == Object.class ? clazz : interceptor.value();
-                    if (interceptors.put(key, new InternalInterceptor(new SimpleBean(null), method)) != null) {
+                    final InternalInterceptor value = new InternalInterceptor(new SimpleBean(null), method);
+
+                    final Class<?> key = clazz;
+                    if (interceptors.put(key, value) != null) {
                         throw new IllegalArgumentException(key + " interceptor is conflicting");
                     }
                 }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/CmdMethod.java
@@ -420,14 +420,16 @@ public class CmdMethod implements Cmd {
     }
 
     public Object exec(final Map<Class<?>, InternalInterceptor> globalInterceptors, final List<Object> list) {
-        return interceptors == null || interceptors.length == 0 ?
-                doInvoke(list) :
-                new InternalInterceptorInvocationContext(globalInterceptors, interceptors, name, parameterMetadatas, method, list) {
-                    @Override
-                    protected Object doInvoke(final List<Object> parameters) {
-                        return CmdMethod.this.doInvoke(parameters);
-                    }
-                }.proceed();
+        if (interceptors == null || interceptors.length == 0) {
+            return doInvoke(list);
+        }
+        
+        return new InternalInterceptorInvocationContext(globalInterceptors, interceptors, name, parameterMetadatas, method, list) {
+            @Override
+            protected Object doInvoke(final List<Object> parameters) {
+                return CmdMethod.this.doInvoke(parameters);
+            }
+        }.proceed();
     }
 
     private List<ParameterMetadata> buildApiParameterViews(final List<Param> parameters) {

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/InterceptorAnnotationNotFoundException.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/InterceptorAnnotationNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Tomitribe and community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.interceptor;
+
+public class InterceptorAnnotationNotFoundException extends IllegalStateException {
+    public InterceptorAnnotationNotFoundException(final Class<?> clazz) {
+        super("@CrestInterceptor not found on any methods of class " + clazz.getName()+".  Expecting a method declaration like the following:" +
+                "        @CrestInterceptor\n" +
+                "        public Object intercept(final CrestContext crestContext) {\n" +
+                "            // do something fun\n" +
+                "            return crestContext.proceed();\n" +
+                "        }\n");
+    }
+}

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/UnresolvedInterceptorAnnotationException.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/UnresolvedInterceptorAnnotationException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Tomitribe and community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.interceptor;
+
+import org.tomitribe.crest.api.Loader;
+
+public class UnresolvedInterceptorAnnotationException extends IllegalStateException {
+    public UnresolvedInterceptorAnnotationException(final Class<?> interceptorClass) {
+        super(message(interceptorClass));
+    }
+
+    private static String message(final Class<?> interceptorClass) {
+        return String.format("Custom interceptor annotation @%s did not resolve.  " +
+                "Please ensure the implementing class is returned by a %s and is" +
+                " also annotated with @%s", interceptorClass.getName(), Loader.class.getName(), interceptorClass.getSimpleName());
+    }
+}

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/internal/InternalInterceptor.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/internal/InternalInterceptor.java
@@ -17,7 +17,10 @@
 package org.tomitribe.crest.interceptor.internal;
 
 import org.tomitribe.crest.api.interceptor.CrestContext;
+import org.tomitribe.crest.api.interceptor.CrestInterceptor;
+import org.tomitribe.crest.cmds.targets.SimpleBean;
 import org.tomitribe.crest.cmds.targets.Target;
+import org.tomitribe.crest.interceptor.InterceptorAnnotationNotFoundException;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -43,5 +46,20 @@ public class InternalInterceptor {
 
     private static Object throwRuntime(final Throwable cause) { // try to propagate if possible
         throw RuntimeException.class.isInstance(cause) ? RuntimeException.class.cast(cause) : new IllegalStateException(cause);
+    }
+
+    public static InternalInterceptor from(final Class<?> clazz){
+        for (final Method method : clazz.getMethods()) {
+            if (Object.class == method.getDeclaringClass()) {
+                continue;
+            }
+
+            final CrestInterceptor interceptor = method.getAnnotation(CrestInterceptor.class);
+            if (interceptor != null) {
+                return new InternalInterceptor(new SimpleBean(null), method);
+            }
+        }
+
+        throw new InterceptorAnnotationNotFoundException(clazz);
     }
 }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/internal/InternalInterceptorInvocationContext.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/internal/InternalInterceptorInvocationContext.java
@@ -18,6 +18,7 @@ package org.tomitribe.crest.interceptor.internal;
 
 import org.tomitribe.crest.api.interceptor.CrestContext;
 import org.tomitribe.crest.api.interceptor.ParameterMetadata;
+import org.tomitribe.crest.interceptor.UnresolvedInterceptorAnnotationException;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -74,6 +75,11 @@ public abstract class InternalInterceptorInvocationContext {
             InternalInterceptor internalInterceptor = interceptors.get(interceptorClass);
 
             if (internalInterceptor == null) {
+
+                if (interceptorClass.isAnnotation()) {
+                    throw new UnresolvedInterceptorAnnotationException(interceptorClass);
+                }
+
                 internalInterceptor = InternalInterceptor.from(interceptorClass);
             }
             index++;

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/internal/InternalInterceptorInvocationContext.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/interceptor/internal/InternalInterceptorInvocationContext.java
@@ -16,8 +16,8 @@
  */
 package org.tomitribe.crest.interceptor.internal;
 
-import org.tomitribe.crest.api.interceptor.ParameterMetadata;
 import org.tomitribe.crest.api.interceptor.CrestContext;
+import org.tomitribe.crest.api.interceptor.ParameterMetadata;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -70,9 +70,11 @@ public abstract class InternalInterceptorInvocationContext {
 
     public Object proceed() {
         if (index < interceptorKeys.length) {
-            final InternalInterceptor internalInterceptor = interceptors.get(interceptorKeys[index]);
+            final Class<?> interceptorClass = interceptorKeys[index];
+            InternalInterceptor internalInterceptor = interceptors.get(interceptorClass);
+
             if (internalInterceptor == null) {
-                throw new IllegalArgumentException("No interceptor for " + interceptorKeys[index].getName());
+                internalInterceptor = InternalInterceptor.from(interceptorClass);
             }
             index++;
             return internalInterceptor.intercept(context);

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/InterceptorTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/InterceptorTest.java
@@ -49,6 +49,18 @@ public class InterceptorTest {
             new Main(InterceptMe.class, In1.class, In2.class, In3.class).exec("test1", "--o1=1", "--o2=2", "--o3=p3", "http://localhost:1253"));
     }
 
+    /**
+     * In this test the interceptors In1.class, In2.class, and In3.class
+     * are not passed into the Main, but discovered via the @CrestInterceptor
+     * annotation declaration
+     */
+    @Test
+    public void intercept2() throws Exception {
+        assertEquals(
+            "replaced2truetruefalsep3http://localhost:1253",
+            new Main(InterceptMe.class).exec("test1", "--o1=1", "--o2=2", "--o3=p3", "http://localhost:1253"));
+    }
+
     @Test
     public void noProceed() throws Exception {
         assertEquals(

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/interceptor/CustomInterceptorAnnotationTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/interceptor/CustomInterceptorAnnotationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2022 Tomitribe and community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.interceptor;
+
+import org.junit.Test;
+import org.tomitribe.crest.Main;
+import org.tomitribe.crest.api.Command;
+import org.tomitribe.crest.api.interceptor.CrestContext;
+import org.tomitribe.crest.api.interceptor.CrestInterceptor;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class CustomInterceptorAnnotationTest {
+
+    @Test
+    public void typical() throws Exception {
+
+        final Main main = new Main(Foo.class);
+
+        assertEquals("GreenInterceptor", main.exec("green", "foo"));
+    }
+
+    @Test
+    public void lessCommon() throws Exception {
+
+        final Main main = new Main(Foo.class);
+
+        assertEquals("YellowInterceptor", main.exec("yellow", "foo"));
+    }
+
+    @Test
+    public void interceptorDirectlyNamed() throws Exception {
+
+        final Main main = new Main(Foo.class);
+
+        assertEquals("RedInterceptor", main.exec("red", "foo"));
+    }
+
+    @Test
+    public void interceptorIndirectlyNamed() throws Exception {
+
+        final Main main = new Main(Foo.class, BlueInterceptor.class);
+
+        assertEquals("BlueInterceptor", main.exec("blue", "foo"));
+    }
+
+    @Test
+    public void interceptorIndirectlyNamedDoesNotResolve() throws Exception {
+
+        final Main main = new Main(Foo.class);
+
+        try {
+            final Object exec = main.exec("blue", "foo");
+            fail("Expected UnresolvedInterceptorAnnotationException");
+        } catch (UnresolvedInterceptorAnnotationException pass) {
+            assertEquals("Custom interceptor annotation " +
+                    "@org.tomitribe.crest.interceptor.CustomInterceptorAnnotationTest$Blue did not resolve." +
+                    "  Please ensure the implementing class is returned by a org.tomitribe.crest.api.Loader" +
+                    " and is also annotated with @Blue", pass.getMessage());
+        }
+    }
+
+    public static class Foo {
+
+        @Command(interceptedBy = GreenInterceptor.class)
+        public static String green(final String arg) {
+            return arg;
+        }
+
+        @Command
+        @CrestInterceptor(YellowInterceptor.class)
+        public static String yellow(final String arg) {
+            return arg;
+        }
+
+        @Red
+        @Command
+        public static String red(final String arg) {
+            return arg;
+        }
+
+        @Blue
+        @Command
+        public static String blue(final String arg) {
+            return arg;
+        }
+    }
+
+    /**
+     * This is the only support that existed in Crest 0.14 and before
+     */
+    public static class GreenInterceptor {
+
+        @CrestInterceptor
+        public Object intercept(final CrestContext crestContext) {
+            final List<Object> parameters = crestContext.getParameters();
+            parameters.set(0, this.getClass().getSimpleName());
+            return crestContext.proceed();
+        }
+    }
+
+    /**
+     * It is possible this was an untested feature of Crest 0.14 and before
+     * Here the @CrestInterceptor method is used on the @Command and explicitly
+     * names the interceptor class.  Use of this style is not recommended.
+     */
+    public static class YellowInterceptor {
+
+        @CrestInterceptor
+        public Object intercept(final CrestContext crestContext) {
+            final List<Object> parameters = crestContext.getParameters();
+            parameters.set(0, this.getClass().getSimpleName());
+            return crestContext.proceed();
+        }
+    }
+
+    /**
+     * In this scenario the custom interceptor annotation (@Red)
+     * explicitly references the intended interceptor, RedInterceptor
+     *
+     * We expect the runtime to see @Red is annotated with @CrestInterceptor
+     * and to directly resolve that to RedInterceptor
+     */
+    @CrestInterceptor(RedInterceptor.class)
+    @Retention(value = RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    public @interface Red {
+    }
+
+    public static class RedInterceptor {
+
+        @CrestInterceptor
+        public Object intercept(final CrestContext crestContext) {
+            final List<Object> parameters = crestContext.getParameters();
+            parameters.set(0, this.getClass().getSimpleName());
+            return crestContext.proceed();
+        }
+    }
+
+    /**
+     * In this scenario the custom interceptor annotation (@Blue)
+     * does not mention the exact interceptor that implements its functionality
+     *
+     * We expect the runtime to scan the list of interceptors available and
+     * look for one that is annotated with @Blue
+     */
+    @CrestInterceptor
+    @Retention(value = RetentionPolicy.RUNTIME)
+    @Target({ElementType.METHOD, ElementType.TYPE})
+    public @interface Blue {
+    }
+
+    @Blue
+    public static class BlueInterceptor {
+
+        @CrestInterceptor
+        public Object intercept(final CrestContext crestContext) {
+            final List<Object> parameters = crestContext.getParameters();
+            parameters.set(0, this.getClass().getSimpleName());
+            return crestContext.proceed();
+        }
+    }
+
+
+}


### PR DESCRIPTION
We now support 3 styles for declaring interceptors

## Original Style via `@Command(interceptedBy)`

The `@Command` declaration uses the `interceptedBy` attribute to name the interceptor class.

    public static class Foo {

        @Command(interceptedBy = GreenInterceptor.class)
        public String fighters(final String arg) {
            return arg;
        }

The `GreenInterceptor` definition is as usual

    public class GreenInterceptor {

        @CrestInterceptor
        public Object intercept(final CrestContext crestContext) {
            return crestContext.proceed();
        }
    }

## Custom annotation containing `@CrestInterceptor(FooInterceptor.class)`

In this style, we define our own custom annotation `@Red` that names `RedInterceptor` directly

    @CrestInterceptor(RedInterceptor.class)
    @Retention(value = RetentionPolicy.RUNTIME)
    @Target({ElementType.METHOD})
    public @interface Red {
    }

...and use it on our `@Command` method as follows

    public static class Foo {

        @Red 
        @Command
        public String fighters(final String arg) {
            return arg;
        }

The `RedInterceptor` definition is as usual

    public class RedInterceptor {

        @CrestInterceptor
        public Object intercept(final CrestContext crestContext) {
            return crestContext.proceed();
        }
    }

## Custom annotation containing `@CrestInterceptor` loosely coupled to an implementation

In this style, we define our own custom annotation `@Blue`, but it is not bound to a specific implementation.  The `@CrestInterceptor` does not mention the class.

    @CrestInterceptor
    @Retention(value = RetentionPolicy.RUNTIME)
    @Target({ElementType.METHOD})
    public @interface Blue {
    }

The `@Blue` is used on our `@Command` method as in the previous example

    public static class Foo {

        @Blue 
        @Command
        public String fighters(final String arg) {
            return arg;
        }

The `BlueInterceptor` definition identifies itself as the implementation of `@Blue` by using that annotation on its class

    @Blue
    public class BlueInterceptor {

        @CrestInterceptor
        public Object intercept(final CrestContext crestContext) {
            return crestContext.proceed();
        }
    }

This can be useful if you create an API jar where `@Blue` might be contained, but you want to put the implementation in a different jar.  Perhaps there are different implementations, each it it's own jar, and people choose the implementation they want by including the desired implementation jar in the classpath.

In this approach, however, it is necessary to ensure `BlueInterceptor.class` is visible to Crest by creating a `Loader` implementation such as the following

    package org.example.myapp;
    
    import java.util.ArrayList;
    import java.util.Arrays;
    import java.util.Collections;
    import java.util.Iterator;
    import java.util.List;
    
    public class Loader implements org.tomitribe.crest.api.Loader {
    
        @Override
        public Iterator<Class<?>> iterator() {
            final List<Class<?>> classes = new ArrayList<>();
            classes.add(BlueInterceptor.class);
            return classes.listIterator();
        }
    }

and declaring it in the jar at `META-INF/services/org.tomitribe.crest.api.Loader` with the following contents:

    org.example.myapp.Loader


