### PR TITLE
enable to keep validations but not require bean validation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Command-line API styled after JAX-RS
 CREST allows you to get to the real work as quickly as possible when writing command line tools in Java.
 
  * 100% annotation based
- * Use Bean Validation on use input
+ * Use Bean Validation or custom validators on use input
  * Contains Several builtin validations
  * Generates help from annotations
  * Supports default values
@@ -548,6 +548,38 @@ bite the bullet and proactively invest in creating a reusable set of validation 
 types.
 
 Pull requests are *very* strongly encouraged for any annotations that might be useful to others.
+
+=== Bean Validation-less validations
+
+You can also use the built-in crest validator style, it enables to lighten the dependencies by not requiring bean validation.
+To do that you must:
+
+. define a custom validation annotation
+. implementation the validation as a `Consumer<ParamType>` or `BiConsumer<AnnotationDefinedIn1, ParamType>`
+
+If the validation fails, the implementation just throws an exception with a meaningful error message.
+
+Here is a trivial example to check a `Path` is a directory:
+
+[source,java]
+----
+ @Target(PARAMETER)
+ @Retention(RUNTIME)
+ @Validation(CrestDirectory.Impl.class)
+ public @interface CrestDirectory {
+ }
+
+ public class Impl implements Consumer<Path> {
+   @Override
+   public void accept(final Path file) {
+       if (!Files.isDirectory(file)) {
+           throw new IllegalStateException("'" + file + "' is not a directory");
+       }
+   }
+}
+----
+
+TIP: the instances of the implementation are looked up by class in the `Environment` and if none matches a plain `new` is done calling the default constructor.
 
 == Maven pom.xml setup
 

--- a/tomitribe-crest-api/src/main/java/org/tomitribe/crest/api/validation/Validation.java
+++ b/tomitribe-crest-api/src/main/java/org/tomitribe/crest/api/validation/Validation.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.api.validation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Mark an annotation as being a command parameter validation.
+ * It takes the implementation as parameter ({@code value()}).
+ * {@code Consumer<V>} and {@code BiConsumer<A, V>} are supported where {@code A} is the annotation and {@code V} the parameter value.
+ * If the validation fails it must throw a runtime exception and the error message will be captured by crest.
+ */
+@Target(ANNOTATION_TYPE)
+@Retention(RUNTIME)
+public @interface Validation {
+    /**
+     * @return the validation implementation.
+     */
+    Class<?> value();
+}

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/processors/Commands.java
@@ -26,6 +26,8 @@ import org.tomitribe.crest.cmds.targets.SimpleBean;
 import org.tomitribe.crest.cmds.targets.Target;
 import org.tomitribe.crest.contexts.DefaultsContext;
 import org.tomitribe.crest.contexts.SystemPropertiesDefaultsContext;
+import org.tomitribe.crest.environments.Environment;
+import org.tomitribe.crest.val.BeanValidationImpl;
 import org.tomitribe.util.Strings;
 import org.tomitribe.util.collect.FilteredIterable;
 import org.tomitribe.util.collect.FilteredIterator;
@@ -46,6 +48,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import static java.util.Arrays.asList;
+import static java.util.Optional.ofNullable;
 
 public class Commands {
 
@@ -89,7 +92,11 @@ public class Commands {
 
         for (final Method method : commands(clazz)) {
 
-            final CmdMethod cmd = new CmdMethod(method, target, dc);
+            final CmdMethod cmd = new CmdMethod(
+                    method, target, dc,
+                    ofNullable(Environment.ENVIRONMENT_THREAD_LOCAL.get())
+                            .map(e -> e.findService(BeanValidationImpl.class))
+                            .orElse(null));
 
             final Cmd existing = map.get(cmd.getName());
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/environments/SystemEnvironment.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/environments/SystemEnvironment.java
@@ -17,9 +17,12 @@
 package org.tomitribe.crest.environments;
 
 
+import org.tomitribe.crest.val.BeanValidation;
+import org.tomitribe.crest.val.BeanValidationImpl;
+
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
@@ -27,11 +30,13 @@ public class SystemEnvironment implements Environment {
     private final Map<Class<?>, Object> services;
 
     public SystemEnvironment(final Map<Class<?>, Object> services) {
-        this.services = services;
+        this.services = new HashMap<>(services);
+        init();
     }
 
     public SystemEnvironment() {
-        this.services = Collections.emptyMap();
+        this.services = new HashMap<>();
+        init();
     }
 
     @Override
@@ -56,5 +61,9 @@ public class SystemEnvironment implements Environment {
     @Override
     public <T> T findService(Class<T> type) {
         return type.cast(services.get(type));
+    }
+
+    protected void init() {
+        services.put(BeanValidationImpl.class, BeanValidation.create(this::findService));
     }
 }

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BVal05.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BVal05.java
@@ -25,7 +25,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Set;
 
-public class BVal05 implements BeanValidation.BeanValidationImpl {
+public class BVal05 extends BeanValidationMessages {
     private static final Class<?>[] NO_GROUP = new Class<?>[0];
 
     private final Class<?> unwrapClass;

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation.java
@@ -16,22 +16,18 @@
  */
 package org.tomitribe.crest.val;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.LinkedList;
-
-import static java.util.Collections.singletonList;
+import java.util.function.Function;
 
 /**
  * A simple interceptor to validate parameters and returned value using
  * bean validation spec. It doesn't use group for now.
  */
 public class BeanValidation {
-    private static final BeanValidationImpl IMPL;
-    static {
+    private BeanValidation() {
+        // no-op
+    }
+
+    public static BeanValidationImpl create(final Function<Class<?>, Object> validatorLookup) {
         BeanValidationImpl impl = null;
         final ClassLoader loader = BeanValidation.class.getClassLoader();
         try {
@@ -45,48 +41,7 @@ public class BeanValidation {
                 // no-op
             }
         }
-        IMPL = impl;
-    }
-
-    private BeanValidation() {
-        // no-op
-    }
-
-    public static boolean isActive() {
-        return IMPL != null;
-    }
-
-    public static void validateParameters(final Object instance, final Method method, final Object[] parameters) throws Exception {
-        if (!isActive()) {
-            return;
-        }
-
-        IMPL.validateParameters(instance, method, parameters);
-    }
-
-    public static void validateParameters(final Constructor constructor, final Object[] parameters) throws Exception {
-        if (!isActive()) {
-            return;
-        }
-
-        IMPL.validateParameters(constructor, parameters);
-    }
-
-    public static Iterable<? extends String> messages(final Exception e) {
-        if (!ConstraintViolationException.class.isInstance(e)) {
-            return singletonList(e.getMessage());
-        }
-        final Collection<String> msg = new LinkedList<>();
-        final ConstraintViolationException cve = (ConstraintViolationException) e;
-        for (final ConstraintViolation<?> violation : cve.getConstraintViolations()) {
-            msg.add(violation.getMessage());
-        }
-        return msg;
-    }
-
-    public interface BeanValidationImpl {
-        void validateParameters(Object instanceOrClass, Method method, Object[] parameters);
-        void validateParameters(Constructor constructor, Object[] parameters);
+        return new BuiltInValidation(impl, validatorLookup);
     }
 }
 

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation11.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidation11.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Set;
 
-public class BeanValidation11 implements BeanValidation.BeanValidationImpl {
+class BeanValidation11 extends BeanValidationMessages {
     private final ValidatorFactory validatorFactory;
 
     public BeanValidation11() {

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidationImpl.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidationImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.val;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+public interface BeanValidationImpl {
+    void validateParameters(Object instanceOrClass, Method method, Object[] parameters);
+
+    void validateParameters(Constructor constructor, Object[] parameters);
+
+    Optional<List<String>> messages(Throwable exception);
+}

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidationMessages.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BeanValidationMessages.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.val;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.toList;
+
+abstract class BeanValidationMessages implements BeanValidationImpl {
+    @Override
+    public Optional<List<String>> messages(final Throwable exception) {
+        return Optional.of(exception)
+                .filter(ConstraintViolationException.class::isInstance)
+                .map(ConstraintViolationException.class::cast)
+                .map(cve -> cve.getConstraintViolations().stream().map(ConstraintViolation::getMessage).collect(toList()));
+    }
+}

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BuiltInValidation.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/val/BuiltInValidation.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.val;
+
+import org.tomitribe.crest.api.validation.Validation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntConsumer;
+import java.util.stream.Stream;
+
+import static java.util.Optional.ofNullable;
+
+public class BuiltInValidation implements BeanValidationImpl {
+    private final BeanValidationImpl sibling;
+    private final Map<Executable, Consumer<Object[]>> validatorPerExecutable = new ConcurrentHashMap<>();
+    private final Function<Class<?>, Object> lookup;
+
+    public BuiltInValidation(final BeanValidationImpl sibling, final Function<Class<?>, Object> lookup) {
+        this.sibling = sibling;
+        this.lookup = lookup;
+    }
+
+    @Override
+    public void validateParameters(final Object instanceOrClass, final Method method, final Object[] parameters) {
+        doValidateParameters(method, parameters);
+        if (sibling != null) {
+            sibling.validateParameters(instanceOrClass, method, parameters);
+        }
+    }
+
+    @Override
+    public void validateParameters(final Constructor constructor, final Object[] parameters) {
+        doValidateParameters(constructor, parameters);
+        if (sibling != null) {
+            sibling.validateParameters(constructor, parameters);
+        }
+    }
+
+    @Override
+    public Optional<List<String>> messages(final Throwable exception) {
+        return Optional.of(exception)
+                .filter(ValidationMessages.class::isInstance)
+                .map(ValidationMessages.class::cast)
+                .map(e -> e.messages);
+    }
+
+    private Object createInstance(final Class<?> value) {
+        return ofNullable(lookup.apply(value)).orElseGet(() -> {
+            try {
+                return value.getConstructor().newInstance();
+            } catch (final InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+                throw new IllegalArgumentException(e);
+            } catch (final InvocationTargetException e) {
+                throw new IllegalStateException(e.getTargetException());
+            }
+        });
+    }
+
+    private void doValidateParameters(final Executable executable, final Object[] parameters) {
+        validatorPerExecutable.computeIfAbsent(executable, e -> {
+            if (executable.getParameterCount() == 0) {
+                return a -> {
+                };
+            }
+            final Consumer[] validators = Stream.of(executable.getParameters())
+                    .map(this::toValidator)
+                    .toArray(Consumer[]::new);
+            return args -> executeValidations(validators.length, i -> validators[i].accept(args[i]));
+        }).accept(parameters);
+    }
+
+    private Consumer<Object> toValidator(final Parameter parameter) {
+        final Consumer[] validations = Stream.of(parameter.getAnnotations())
+                .filter(it -> it.annotationType().isAnnotationPresent(Validation.class))
+                .map(it -> {
+                    final Class<?> value = it.annotationType().getAnnotation(Validation.class).value();
+                    final Object validationInstance = createInstance(value);
+                    if (Consumer.class.isInstance(validationInstance)) {
+                        return Consumer.class.cast(validationInstance);
+                    }
+                    if (BiConsumer.class.isInstance(validationInstance)) {
+                        final BiConsumer<Annotation, Object> biConsumer = BiConsumer.class.cast(validationInstance);
+                        return (Consumer<Object>) a -> biConsumer.accept(it, a);
+                    }
+                    throw new IllegalArgumentException("Invalid validation, expected Consumer or BiConsumer but got " + value);
+                })
+                .toArray(Consumer[]::new);
+        if (validations.length == 0) {
+            return a -> {
+            };
+        }
+        return a -> executeValidations(validations.length, i -> validations[i].accept(a));
+    }
+
+    private <T> void executeValidations(final int max, final IntConsumer validate) {
+        ValidationMessages exception = null;
+        for (int i = 0; i < max; i++) {
+            try {
+                validate.accept(i);
+            } catch (final RuntimeException re) {
+                if (exception == null) {
+                    exception = new ValidationMessages(new ArrayList<>());
+                }
+                if (ValidationMessages.class.isInstance(re)) {
+                    exception.messages.addAll(ValidationMessages.class.cast(re).messages);
+                } else {
+                    exception.messages.add(re.getMessage());
+                }
+            }
+        }
+        if (exception != null) {
+            throw exception;
+        }
+    }
+
+    private static class ValidationMessages extends RuntimeException {
+        private final List<String> messages;
+
+        private ValidationMessages(final List<String> messages) {
+            super(String.join(", ", messages));
+            this.messages = messages;
+        }
+    }
+}

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/BeanValidationTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/BeanValidationTest.java
@@ -20,19 +20,46 @@ import org.apache.bval.constraints.NotEmpty;
 import org.junit.Assert;
 import org.junit.Test;
 import org.tomitribe.crest.api.Command;
+import org.tomitribe.crest.api.validation.Validation;
 import org.tomitribe.crest.cmds.Cmd;
 import org.tomitribe.crest.cmds.HelpPrintedException;
 import org.tomitribe.crest.cmds.processors.Commands;
+import org.tomitribe.crest.val.BuiltInValidation;
 import org.tomitribe.crest.val.Directory;
 
 import javax.validation.ConstraintViolationException;
 import java.io.File;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.util.Map;
+import java.util.function.Consumer;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static java.util.Collections.singletonList;
 
 /**
  * @version $Revision$ $Date$
  */
 public class BeanValidationTest extends Assert {
+
+    @Test
+    public void invalidBuiltIn() {
+        final Map<String, Cmd> cmds = Commands.get(BuiltIn.class);
+        final Cmd check = cmds.get("check");
+        check.exec(null, new File("").getAbsolutePath());
+        try {
+            check.exec(null, new File("/this/does/not/exist/we/hope").getAbsolutePath());
+            fail();
+        } catch (final HelpPrintedException e) {
+            assertEquals(
+                    singletonList("'/this/does/not/exist/we/hope' is not a directory"),
+                    new BuiltInValidation(null, null)
+                            .messages(e.getCause())
+                            .orElseThrow(IllegalStateException::new));
+        }
+    }
+
 
     @Test
     public void invalidOptions() {
@@ -64,4 +91,24 @@ public class BeanValidationTest extends Assert {
         }
     }
 
+
+    public static class BuiltIn {
+        @Command
+        public void check(@CrestDirectory final File dir) {
+        }
+    }
+
+    @Target(PARAMETER)
+    @Retention(RUNTIME)
+    @Validation(CrestDirectory.Impl.class)
+    public @interface CrestDirectory {
+        class Impl implements Consumer<File> {
+            @Override
+            public void accept(final File file) {
+                if (!file.isDirectory()) {
+                    throw new IllegalStateException("'" + file + "' is not a directory");
+                }
+            }
+        }
+    }
 }

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/HelpTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/HelpTest.java
@@ -230,7 +230,7 @@ public class HelpTest extends Assert {
                 continue;
             }
             
-            CmdMethod cmd = new CmdMethod(method, new SimpleBean(null));
+            CmdMethod cmd = new CmdMethod(method, new SimpleBean(null), null);
             assertCommandHelp(clazz, cmd, helpFileName(Git.class, "git", methodName));
         }
     }


### PR DESCRIPTION
I always drop bean validation from crest cause:

1. it is a bit fat for what it does
2. it is slow (for a CLI)
3. it is too complex to implement a constraint (the annotation definition is way too verbose and the validator implementation is in 2 steps and requires to have a step which is not that nice)

overall I tend to always implement a custom validation interceptor to replace it

Since crest already has bean validation support wired, I just enhance it to support a built-in validator type so think it can be worth to have it built-in.

Longer term food for thought: can a parameter annotation trigger an interceptor (= be considered as interceptor binding)? This would enable to move the validation logic to an interceptor without requiring to define the interceptor + the validations but just the validations :).