### PR TITLE
enable to run commands from a standalone java file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1371,3 +1371,50 @@ Just set extension property `tomitribe.crest.useInPlaceRegistrations` to `true`:
 ----
 
 This enables to use the same scanning for both tasks and therefore to have a common and unified scanning for java and native runs.
+
+== Run commands from source
+
+There is an experimental mode in crest enabling you to write commands in a standalone `.java` and run it with `tomitribe-crest.jar` fatjar directly.
+The trick is to pass as first parameter `--crest.source=/path/to/file/with/commands.java`.
+
+[source,java]
+.commands.java
+----
+import org.tomitribe.crest.api.Command;
+import java.time.LocalDate;
+
+class Command1 {
+    @Command
+    String ok() {
+        return "ok";
+    }
+}
+
+@Command
+class Command2 {
+    @Command
+    String time() {
+        return LocalDate.now().toString();
+    }
+}
+----
+
+IMPORTANT: this mode has some limitation like not supporting (yet) a dynamic classpath so it just uses the script and the launching classpath.
+
+TIP: to ease writing scripts with completion the lines starting with `//-- ` will drop this prefix.
+It avoids compilations errors in general on classes no in the classpath (crest there).
+
+Usage example:
+
+[source,bash]
+----
+java \
+  -jar tomitribe-crest-0.20-fatjar.jar \
+  --crest.source=mycommands.java \
+  my-command \
+  --foo=bar
+----
+
+IMPORTANT: this requires to run with a *JDK* to work.
+
+TIP: you can also use it in a script easily.

--- a/tomitribe-crest-arthur-extension/src/main/java/org/tomitribe/crest/arthur/svm/MainSubstitute.java
+++ b/tomitribe-crest-arthur-extension/src/main/java/org/tomitribe/crest/arthur/svm/MainSubstitute.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.arthur.svm;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.tomitribe.crest.Main;
+
+@TargetClass(Main.class)
+public final class MainSubstitute {
+    @Substitute
+    private void handleSource(final String command) {
+        throw new UnsupportedOperationException("In native mode, compiler feature is disabled");
+    }
+}

--- a/tomitribe-crest-arthur-extension/src/main/java/org/tomitribe/crest/arthur/svm/SimpleCompilerDelete.java
+++ b/tomitribe-crest-arthur-extension/src/main/java/org/tomitribe/crest/arthur/svm/SimpleCompilerDelete.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.arthur.svm;
+
+import com.oracle.svm.core.annotate.Delete;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.tomitribe.crest.compiler.SimpleCompiler;
+
+@Delete("native mode will not support compilation on the fly")
+@TargetClass(SimpleCompiler.class)
+public final class SimpleCompilerDelete {
+}

--- a/tomitribe-crest/pom.xml
+++ b/tomitribe-crest/pom.xml
@@ -81,16 +81,22 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.google.auto.service</groupId>
-      <artifactId>auto-service</artifactId>
-      <version>1.0-rc2</version>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <configuration>
+              <proc>none</proc>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -102,6 +108,42 @@
             <test.env.value>test-sys-value</test.env.value>
           </systemPropertyVariables>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>fatjar</shadedClassifierName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.tomitribe.crest.Main</mainClass>
+                </transformer>
+              </transformers>
+              <artifactSet>
+                <excludes>
+                  <exclude>org.apache.xbean:*</exclude>
+                </excludes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/LICENSE.txt</exclude>
+                    <exclude>META-INF/NOTICE.txt</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/targets/SimpleBean.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/cmds/targets/SimpleBean.java
@@ -44,15 +44,26 @@ public class SimpleBean implements Target {
             return bean;
         }
         if (Modifier.isStatic(method.getModifiers())) {
-            return bean;
+            return null;
         }
 
         try {
             final Class<?> declaringClass = method.getDeclaringClass();
             final Constructor<?> constructor = declaringClass.getConstructor();
             return constructor.newInstance();
-        } catch (final NoSuchMethodException e) {
-            return null;
+        } catch (final NoSuchMethodException | IllegalAccessException e) {
+            try {
+                final Class<?> declaringClass = method.getDeclaringClass();
+                final Constructor<?> constructor = declaringClass.getDeclaredConstructor();
+                if (!constructor.isAccessible()) {
+                    constructor.setAccessible(true);
+                }
+                return constructor.newInstance();
+            } catch (final NoSuchMethodException e2) {
+                return null;
+            } catch (final Throwable e2) {
+                throw new IllegalStateException(e);
+            }
         } catch (final InvocationTargetException e) {
             throw new IllegalStateException(e.getCause());
         } catch (final Throwable e) {

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/compiler/SimpleCompiler.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/compiler/SimpleCompiler.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.compiler;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.FileObject;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singleton;
+
+public final class SimpleCompiler {
+    private SimpleCompiler() {
+        // no-op
+    }
+
+    public static MemoryLoader compile(final String file) {
+        final Path path = Paths.get(file);
+        if (!Files.exists(path)) {
+            throw new IllegalArgumentException("No source file at '" + path.toAbsolutePath().normalize() + "'");
+        }
+
+        final Locale locale = Locale.getDefault();
+        final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        final DiagnosticCollector<JavaFileObject> collector = new DiagnosticCollector<>();
+        final MemoryLoader loader = new MemoryLoader();
+        try {
+            final JavaFileObject from = new StringInputJavaFileObject(
+                    path.toAbsolutePath().normalize().toUri(),
+                    new String(Files.readAllBytes(path)).replace("//-- ", ""));
+            final JavaCompiler.CompilationTask task = compiler.getTask(
+                    null,
+                    new ForwardingJavaFileManager<JavaFileManager>(compiler.getStandardFileManager(null, locale, UTF_8)) {
+                        @Override
+                        public JavaFileObject getJavaFileForOutput(final Location location, final String className,
+                                                                   final JavaFileObject.Kind kind, final FileObject sibling) {
+                            final ClassOutputJavaFileObject clazz = new ClassOutputJavaFileObject(URI.create("class://" + className + ".class"), className);
+                            loader.registry.put(className, clazz.bytecode::toByteArray);
+                            return clazz;
+                        }
+                    },
+                    collector, null, null,
+                    singleton(from));
+
+            boolean success = task.call();
+            final List<Diagnostic<? extends JavaFileObject>> diagnostics = collector.getDiagnostics();
+            if (!diagnostics.isEmpty()) {
+                final Logger logger = Logger.getLogger(SimpleCompiler.class.getName());
+                success = diagnostics.stream()
+                        .peek(d -> logMessage(locale, logger, d))
+                        .reduce(success, (c, it) -> it.getKind() != Diagnostic.Kind.ERROR && c, (a, b) -> a && b);
+            }
+
+            if (!success) {
+                throw new IllegalStateException("Invalid compilation of '" + path.toAbsolutePath().normalize() + "'");
+            }
+            return loader;
+        } catch (final IOException ioe) {
+            throw new IllegalStateException(ioe);
+        }
+    }
+
+    private static void logMessage(final Locale locale, final Logger logger, Diagnostic<? extends JavaFileObject> d) {
+        final String message = "" +
+                "[" + (d.getSource() == null ? "-" : d.getSource().toUri()) + "]" +
+                "[" + d.getLineNumber() + ", " + d.getColumnNumber() + "] " +
+                d.getMessage(locale);
+        switch (d.getKind()) {
+            case ERROR:
+                logger.severe(message);
+                break;
+
+            // keep in mind it stays a cli so we don't want these errors generally
+            case WARNING:
+            case MANDATORY_WARNING: // it is generally ok to ignore them
+                logger.fine(message);
+                break;
+            default: // more than ok to ignore
+                logger.finest(message);
+        }
+    }
+
+    public static class MemoryLoader extends ClassLoader {
+        private final Map<String, Supplier<byte[]>> registry = new HashMap<>();
+
+        @Override
+        protected Class<?> findClass(final String name) throws ClassNotFoundException {
+            final Supplier<byte[]> bytes = registry.get(name);
+            if (bytes != null) {
+                final byte[] content = bytes.get();
+                return defineClass(name, content, 0, content.length);
+            }
+            return super.findClass(name);
+        }
+
+        public Stream<Class<?>> ownedClasses() {
+            return registry.keySet().stream().map(name -> {
+                try {
+                    return loadClass(name);
+                } catch (final ClassNotFoundException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            });
+        }
+    }
+
+    private static class ClassOutputJavaFileObject extends SimpleJavaFileObject {
+        private final ByteArrayOutputStream bytecode = new ByteArrayOutputStream();
+        private final String className;
+
+        private ClassOutputJavaFileObject(final URI uri, final String className) {
+            super(uri, Kind.CLASS);
+            this.className = className;
+        }
+
+        @Override
+        public OutputStream openOutputStream() {
+            return bytecode;
+        }
+    }
+
+    private static class StringInputJavaFileObject extends SimpleJavaFileObject {
+        private final String source;
+
+        private StringInputJavaFileObject(final URI uri, String content) {
+            super(uri, Kind.SOURCE);
+            this.source = content;
+        }
+
+        @Override
+        public CharSequence getCharContent(final boolean ignoreEncodingErrors) {
+            return source;
+        }
+    }
+}

--- a/tomitribe-crest/src/main/java/org/tomitribe/crest/help/HelpProcessor.java
+++ b/tomitribe-crest/src/main/java/org/tomitribe/crest/help/HelpProcessor.java
@@ -17,13 +17,11 @@
 package org.tomitribe.crest.help;
 
 
-import com.google.auto.service.AutoService;
 import org.tomitribe.crest.api.Command;
 import org.tomitribe.crest.api.Option;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -44,9 +42,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@AutoService(Processor.class)
 public class HelpProcessor extends AbstractProcessor {
-
     @Override
     public Set<String> getSupportedAnnotationTypes() {
         final Set<String> annotations = new LinkedHashSet<String>();

--- a/tomitribe-crest/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/tomitribe-crest/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.tomitribe.crest.help.HelpProcessor

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/MainCompilerTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/MainCompilerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.tomitribe.crest.api.Command;
+import org.tomitribe.crest.compiler.SimpleCompiler;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MainCompilerTest {
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void compile() throws Exception {
+        final Path source = folder.getRoot().toPath().resolve("Source.java");
+        Files.write(source, ("" +
+                "//-- import org.tomitribe.crest.api.Command;\n" +
+                "\n" +
+                "//-- @Command\n" +
+                "class MyCommand2 {\n" +
+                "  //-- @Command\n" +
+                "  public static String test() { return \"ok\"; }\n" +
+                "}\n" +
+                "\n" +
+                "").getBytes(StandardCharsets.UTF_8));
+        assertEquals("ok", new Main(emptyList()).exec("--crest.source=" + source, "myCommand2", "test"));
+    }
+}

--- a/tomitribe-crest/src/test/java/org/tomitribe/crest/compiler/SimpleCompilerTest.java
+++ b/tomitribe-crest/src/test/java/org/tomitribe/crest/compiler/SimpleCompilerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.crest.compiler;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.tomitribe.crest.Main;
+import org.tomitribe.crest.api.Command;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SimpleCompilerTest {
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void compile() throws Exception {
+        final Path source = folder.getRoot().toPath().resolve("Source.java");
+        Files.write(source, ("" +
+                "@org.tomitribe.crest.api.Command\n" +
+                "class MyCommand2 {\n" +
+                "  @org.tomitribe.crest.api.Command\n" +
+                "  public static String test() { return \"ok\"; }\n" +
+                "}\n" +
+                "public class Source {\n" +
+                "}\n" +
+                "\n" +
+                "").getBytes(StandardCharsets.UTF_8));
+
+        final SimpleCompiler.MemoryLoader loader = SimpleCompiler.compile(source.toString());
+        assertEquals(
+                asList("MyCommand2", "Source"),
+                loader.ownedClasses().map(Class::getName).sorted().collect(toList()));
+
+        final Class<?> myCommand2 = loader.loadClass("MyCommand2");
+        assertTrue(myCommand2.isAnnotationPresent(Command.class));
+
+        final Main main = new Main(myCommand2);
+        assertEquals("ok", main.exec("myCommand2", "test"));
+    }
+}


### PR DESCRIPTION
Idea behind this PR is to enable to use crest in standalone files (for simple and quick automotion).

Content should be plain commands.
To avoid the issue to have to add crest to the classpath, we have the hack to support to drop some special comments from the source (`//-- ` is dropped, we should likely enhance it to support `/*-- xxx --*/` to become `xxx` for options) which enables to code with a plain JDK.
To run the source file directly we use the JDK and ToolProvider (to get javac).
Then last trick is to pass as first parameter to crest `--crest.source=/path/to/commands.java` and we are done.
To ease this usage, a fatjar including tomitribe-util was done in tomitribe-crest.
Last change was to support not public commands (a detail but very nice in scripts).

The big benefit is to not require a project for all the small automotion we can write in our projects.

There are still some enhancements to this feature but I guess it is big enough for a first PR but here what can be the follow up:

1. commands for inline annotations (options, defaultvalue etc)
2. support multiple source files (CSV) enabling to have one command per file for ex
3. enable to configure the compilation classpath if needed
4. David special one: we are not far to be able to write commands source as a script if first line is a shebang and we ignore it, requires to drop the line + offset the compilation errors (if any) + have a special "input" path which would be "self" but does not sound crazy and can be quite promishing as usage

Hope it makes sense.